### PR TITLE
Refine pen controls and responsive layouts

### DIFF
--- a/ClassroomTools.py
+++ b/ClassroomTools.py
@@ -17,6 +17,7 @@ from PyQt6.QtCore import (
     QPoint,
     QPointF,
     QRect,
+    QRectF,
     QSize,
     Qt,
     QTimer,
@@ -63,17 +64,94 @@ from PyQt6.QtWidgets import (
 
 # ---------- 图标 ----------
 class IconManager:
-    """集中管理浮动工具条的 SVG 图标，方便后续统一换肤。"""
+    """集中管理浮动工具条的图标，方便后续统一换肤。"""
     _icons: Dict[str, str] = {
         "cursor": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8cGF0aCBmaWxsPScjZjFmM2Y0JyBkPSdNNCAzLjMgMTEuNCAyMWwxLjgtNS44IDYuMy0yLjF6Jy8+CiAgICA8cGF0aCBmaWxsPScjOGFiNGY4JyBkPSdtMTIuNiAxNC40IDQuOCA0LjgtMi4xIDIuMS00LjItNC4yeicvPgo8L3N2Zz4=",
-        "brush": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8cGF0aCBmaWxsPScjZjFmM2Y0JyBkPSdNMTUuOSA0LjJhMyAzIDAgMCAxIDQuMiAwbC4xLjFhMyAzIDAgMCAxIDAgNC4ybC03LjggNy45LTQuNiAxLjIgMS4yLTQuNnonLz4KICAgIDxwYXRoIGZpbGw9JyM4YWI0ZjgnIGQ9J000LjMgMTYuNGEzIDMgMCAwIDAtLjggMi41IDMgMyAwIDAgMCAyLjUtLjggMiAyIDAgMCAwIDAtMi44IDIgMiAwIDAgMC0yLjggMHonLz4KPC9zdmc+",
         "shape": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8cmVjdCB4PSczLjUnIHk9JzMuNScgd2lkdGg9JzknIGhlaWdodD0nOScgcng9JzInIGZpbGw9JyNmMWYzZjQnLz4KICAgIDxjaXJjbGUgY3g9JzE2LjUnIGN5PScxNi41JyByPSc1LjUnIGZpbGw9J25vbmUnIHN0cm9rZT0nI2YxZjNmNCcgc3Ryb2tlLXdpZHRoPScxLjgnLz4KICAgIDxjaXJjbGUgY3g9JzE2LjUnIGN5PScxNi41JyByPSczLjUnIGZpbGw9JyM4YWI0ZjgnIGZpbGwtb3BhY2l0eT0nMC4zNScvPgo8L3N2Zz4=",
-        "eraser": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8cGF0aCBmaWxsPScjZjFmM2Y0JyBkPSdtNSAxNC42IDgtOGEyLjggMi44IDAgMCAxIDQgMGwuOS45YTIuOCAyLjggMCAwIDEgMCA0bC04IDhINi40bC0xLjktMS45YTIgMiAwIDAgMSAwLTIuOHonLz4KICAgIDxyZWN0IHg9JzQnIHk9JzE5JyB3aWR0aD0nMTEnIGhlaWdodD0nMicgcng9JzEnIGZpbGw9JyM4YWI0ZjgnLz4KPC9zdmc+",
-        "clear_all": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8cmVjdCB4PSczLjInIHk9JzQuMicgd2lkdGg9JzE3LjYnIGhlaWdodD0nMTEuNicgcng9JzInIHJ5PScyJyBmaWxsPSdub25lJyBzdHJva2U9JyNmMWYzZjQnIHN0cm9rZS13aWR0aD0nMS42Jy8+CiAgICA8cGF0aCBkPSdNNy4yIDE3LjJoOS42YTEgMSAwIDAgMSAxIDF2MS42SDYuMnYtMS42YTEgMSAwIDAgMSAxLTF6JyBmaWxsPScjOGFiNGY4Jy8+CiAgICA8cGF0aCBkPSdNOC41IDhoNk04LjUgMTEuNWg0JyBzdHJva2U9JyNmMWYzZjQnIHN0cm9rZS13aWR0aD0nMS42JyBzdHJva2UtbGluZWNhcD0ncm91bmQnLz4KPC9zdmc+",
         "settings": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8Y2lyY2xlIGN4PScxMicgY3k9JzEyJyByPSczLjUnIGZpbGw9JyM4YWI0ZjgnLz4KICAgIDxwYXRoIGZpbGw9J25vbmUnIHN0cm9rZT0nI2YxZjNmNCcgc3Ryb2tlLXdpZHRoPScxLjYnIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCcKICAgICAgICBkPSdNMTIgNC41VjIuOG0wIDE4LjR2LTEuN203LjEtNy41SDIwbS0xOCAwaDEuNk0xNy42IDZsMS4yLTEuMk01LjIgMTguNCA2LjQgMTcuMk02LjQgNiA1LjIgNC44bTEzLjYgMTMuNi0xLjItMS4yJy8+Cjwvc3ZnPg==",
         "whiteboard": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgICA8cmVjdCB4PSczJyB5PSc0JyB3aWR0aD0nMTgnIGhlaWdodD0nMTInIHJ4PScyJyByeT0nMicgZmlsbD0nI2YxZjNmNCcgZmlsbC1vcGFjaXR5PScwLjEyJyBzdHJva2U9JyNmMWYzZjQnIHN0cm9rZS13aWR0aD0nMS42Jy8+CiAgICA8cGF0aCBkPSdtNyAxOCA1LTUgNSA1JyBmaWxsPSdub25lJyBzdHJva2U9JyM4YWI0ZjgnIHN0cm9rZS13aWR0aD0nMS44JyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnLz4KICAgIDxwYXRoIGQ9J004IDloOG0tOCAzaDUnIHN0cm9rZT0nI2YxZjNmNCcgc3Ryb2tlLXdpZHRoPScxLjYnIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcvPgo8L3N2Zz4=",
+        "undo": "PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+CiAgPHBhdGggZmlsbD0nI2YxZjNmNCcgZD0nTTguNCA1LjJMMyAxMC42bDUuNCA1LjQgMS40LTEuNC0yLjMtMi4zaDUuNWMzLjIgMCA1LjggMi42IDUuOCA1LjggMCAuNS0uMSAxLS4yIDEuNWwyLjEuNmMuMi0uNy4zLTEuNC4zLTIuMSAwLTQuNC0zLjYtOC04LThINy41bDIuMy0yLjMtMS40LTEuNHonLz4KPC9zdmc+",
     }
     _cache: Dict[str, QIcon] = {}
+
+    @classmethod
+    def get_brush_icon(cls, color_hex: str) -> QIcon:
+        key = f"brush_{color_hex.lower()}"
+        if key in cls._cache:
+            return cls._cache[key]
+        pixmap = QPixmap(28, 28)
+        pixmap.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        brush_color = QColor(color_hex)
+        if not brush_color.isValid():
+            brush_color = QColor("#999999")
+        painter.setBrush(QBrush(brush_color))
+        painter.setPen(QPen(QColor(0, 0, 0, 140), 1.4))
+        painter.drawEllipse(5, 6, 18, 18)
+        painter.setPen(QPen(QColor(255, 255, 255, 230), 3, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
+        painter.drawLine(9, 10, 18, 19)
+        painter.setPen(QPen(QColor(0, 0, 0, 90), 2, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
+        painter.drawLine(10, 9, 19, 18)
+        painter.end()
+        icon = QIcon(pixmap)
+        cls._cache[key] = icon
+        return icon
+
+    @classmethod
+    def _generate_icon(cls, name: str) -> Optional[QIcon]:
+        pixmap = QPixmap(32, 32)
+        pixmap.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        if name == "eraser":
+            painter.translate(pixmap.width() / 2, pixmap.height() / 2)
+            painter.rotate(-28)
+            body_rect = QRectF(-9.2, -5.6, 18.4, 11.2)
+            painter.setPen(QPen(QColor(40, 44, 52, 180), 1.3))
+            painter.setBrush(QColor("#f8cdd1"))
+            painter.drawRoundedRect(body_rect, 3.6, 3.6)
+
+            top_rect = QRectF(body_rect.left(), body_rect.top(), body_rect.width(), body_rect.height() * 0.45)
+            painter.setBrush(QColor("#8ab4f8"))
+            painter.drawRoundedRect(top_rect, 3.4, 3.4)
+
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(255, 255, 255, 130))
+            gloss_rect = QRectF(top_rect.left() + 1.1, top_rect.bottom() - top_rect.height() * 0.65, top_rect.width() - 2.2, top_rect.height() * 0.6)
+            painter.drawRoundedRect(gloss_rect, 2.2, 2.2)
+
+            painter.end()
+            return QIcon(pixmap)
+
+        if name in {"clear_all", "clear"}:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor("#fbbc04"))
+            bristles = QPainterPath()
+            bristles.moveTo(6.5, 20.0)
+            bristles.quadTo(13.0, 27.0, 22.5, 20.8)
+            bristles.lineTo(21.0, 15.0)
+            bristles.quadTo(13.8, 19.5, 6.5, 20.0)
+            painter.drawPath(bristles)
+
+            painter.setBrush(QColor("#fff3d4"))
+            painter.drawEllipse(QRectF(5.4, 5.4, 5.0, 5.0))
+
+            painter.setPen(QPen(QColor("#8d6e63"), 3.1, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
+            painter.drawLine(QPointF(11.0, 6.5), QPointF(23.0, 21.5))
+            painter.setPen(QPen(QColor(250, 250, 250, 220), 1.5, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
+            painter.drawLine(QPointF(11.6, 6.2), QPointF(18.4, 13.2))
+
+            painter.setPen(QPen(QColor("#c68400"), 1.0, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
+            painter.drawLine(QPointF(10.4, 17.5), QPointF(14.0, 22.4))
+            painter.drawLine(QPointF(14.8, 17.0), QPointF(18.4, 21.2))
+
+            painter.end()
+            return QIcon(pixmap)
+
+        painter.end()
+        return None
 
     @classmethod
     def get_icon(cls, name: str) -> QIcon:
@@ -82,6 +160,12 @@ class IconManager:
             name = "clear_all"  # 兼容旧配置
         if name in cls._cache:
             return cls._cache[name]
+
+        generated = cls._generate_icon(name)
+        if generated is not None:
+            cls._cache[name] = generated
+            return generated
+
         data = cls._icons.get(name)
         if not data:
             return QIcon()
@@ -156,6 +240,25 @@ def geometry_to_text(widget: QWidget) -> str:
     return f"{rect.width()}x{rect.height()}+{rect.x()}+{rect.y()}"
 
 
+def _available_geometry(widget: QWidget):
+    screen = widget.screen() or QApplication.primaryScreen()
+    return screen.availableGeometry() if screen else None
+
+
+def _clamp_widget_position(widget: QWidget, x: int, y: int) -> QPoint:
+    available = _available_geometry(widget)
+    if not available:
+        return QPoint(x, y)
+    geom = widget.frameGeometry()
+    width = geom.width() or widget.width() or 1
+    height = geom.height() or widget.height() or 1
+    max_x = available.left() + max(0, available.width() - width)
+    max_y = available.top() + max(0, available.height() - height)
+    clamped_x = max(available.left(), min(x, max_x))
+    clamped_y = max(available.top(), min(y, max_y))
+    return QPoint(clamped_x, clamped_y)
+
+
 def apply_geometry_from_text(widget: QWidget, geometry: str) -> None:
     if not geometry:
         return
@@ -173,8 +276,24 @@ def apply_geometry_from_text(widget: QWidget, geometry: str) -> None:
         y = int(y_str)
     except ValueError:
         return
-    widget.resize(max(160, width), max(120, height))
-    widget.move(x, y)
+    available = _available_geometry(widget)
+    if available:
+        min_w = max(180, int(available.width() * 0.18))
+        max_w = max(min(available.width(), int(available.width() * 0.94)), min_w)
+        min_h = max(140, int(available.height() * 0.18))
+        max_h = max(min(available.height(), int(available.height() * 0.94)), min_h)
+    else:
+        min_w = 160
+        max_w = 960
+        min_h = 120
+        max_h = 720
+
+    width = max(min_w, min(width, max_w))
+    height = max(min_h, min(height, max_h))
+    widget.resize(width, height)
+
+    pos = _clamp_widget_position(widget, x, y)
+    widget.move(pos)
 
 
 def str_to_bool(value: str, default: bool = False) -> bool:
@@ -283,10 +402,9 @@ class TipWindow(QWidget):
 class PenSettingsDialog(QDialog):
     """画笔粗细与颜色选择对话框。"""
     COLORS = {
-        "#000000": "黑",
-        "#FF0000": "红",
-        "#1E90FF": "蓝",
         "#FFFF00": "黄",
+        "#FFA500": "橙",
+        "#24B47E": "绿",
         "#800080": "紫",
         "#FFFFFF": "白",
     }
@@ -298,7 +416,7 @@ class PenSettingsDialog(QDialog):
         self.pen_color = QColor(initial_color)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(6)
 
         size_layout = QHBoxLayout()
@@ -321,9 +439,11 @@ class PenSettingsDialog(QDialog):
         color_layout.setSpacing(6)
         for index, (color_hex, name) in enumerate(self.COLORS.items()):
             button = QPushButton()
-            button.setFixedSize(26, 26)
+            button.setFixedSize(24, 24)
             button.setCursor(Qt.CursorShape.PointingHandCursor)
-            button.setStyleSheet(f"background-color: {color_hex}; border: 1px solid #5f6368; border-radius: 4px;")
+            button.setStyleSheet(
+                f"background-color: {color_hex}; border: 1px solid rgba(0, 0, 0, 60); border-radius: 12px;"
+            )
             button.setToolTip(name)
             button.clicked.connect(lambda _checked, c=color_hex: self._select_color(c))
             color_layout.addWidget(button, index // 3, index % 3)
@@ -419,17 +539,17 @@ class TitleBar(QWidget):
 
         self.setAutoFillBackground(True)
         palette = self.palette()
-        palette.setColor(self.backgroundRole(), QColor(42, 43, 46, 235))
+        palette.setColor(self.backgroundRole(), QColor(36, 37, 41, 235))
         self.setPalette(palette)
-        self.setFixedHeight(24)
+        self.setFixedHeight(22)
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 0, 8, 0)
+        layout.setContentsMargins(6, 0, 6, 0)
         title = QLabel("屏幕批注")
         font = title.font()
         font.setBold(True)
         title.setFont(font)
-        title.setStyleSheet("color: #f1f3f4; font-size: 11px;")
+        title.setStyleSheet("color: #f1f3f4; font-size: 10.5px;")
         layout.addWidget(title)
         layout.addStretch()
 
@@ -481,6 +601,8 @@ class FloatingToolbar(QWidget):
         self.move(int(settings.get("x", "260")), int(settings.get("y", "260")))
         self.adjustSize()
         self.setFixedSize(self.sizeHint())
+        pos = _clamp_widget_position(self, self.x(), self.y())
+        self.move(pos)
 
     def _build_ui(self) -> None:
         self.setStyleSheet(
@@ -495,9 +617,9 @@ class FloatingToolbar(QWidget):
                 background: rgba(60, 64, 67, 240);
                 border: 1px solid rgba(255, 255, 255, 45);
                 border-radius: 6px;
-                padding: 4px;
-                min-width: 30px;
-                min-height: 30px;
+                padding: 3px;
+                min-width: 28px;
+                min-height: 28px;
             }
             QPushButton:hover {
                 background: rgba(138, 180, 248, 245);
@@ -523,34 +645,49 @@ class FloatingToolbar(QWidget):
         root.addWidget(container)
 
         layout = QVBoxLayout(container)
-        layout.setContentsMargins(8, 6, 8, 6)
-        layout.setSpacing(6)
+        layout.setContentsMargins(6, 5, 6, 6)
+        layout.setSpacing(5)
         self.title_bar = TitleBar(self)
         layout.addWidget(self.title_bar)
 
         button_row = QHBoxLayout()
         button_row.setContentsMargins(0, 0, 0, 0)
-        button_row.setSpacing(4)
+        button_row.setSpacing(3)
 
         self.btn_cursor = QPushButton(IconManager.get_icon("cursor"), "")
-        self.btn_brush = QPushButton(IconManager.get_icon("brush"), "")
+        self.brush_color_buttons: Dict[str, QPushButton] = {}
+        brush_configs = [
+            ("#000000", "黑色画笔"),
+            ("#FF0000", "红色画笔"),
+            ("#1E90FF", "蓝色画笔"),
+        ]
+        brush_buttons = []
+        for color_hex, name in brush_configs:
+            button = QPushButton(IconManager.get_brush_icon(color_hex), "")
+            button.setToolTip(name)
+            self.brush_color_buttons[color_hex.lower()] = button
+            brush_buttons.append(button)
         self.btn_shape = QPushButton(IconManager.get_icon("shape"), "")
+        self.btn_undo = QPushButton(IconManager.get_icon("undo"), "")
         self.btn_eraser = QPushButton(IconManager.get_icon("eraser"), "")
         self.btn_clear_all = QPushButton(IconManager.get_icon("clear_all"), "")
         self.btn_whiteboard = QPushButton(IconManager.get_icon("whiteboard"), "")
         self.btn_settings = QPushButton(IconManager.get_icon("settings"), "")
 
         buttons = (
-            self.btn_cursor,
-            self.btn_brush,
-            self.btn_shape,
-            self.btn_eraser,
-            self.btn_clear_all,
-            self.btn_whiteboard,
-            self.btn_settings,
+            [self.btn_cursor]
+            + brush_buttons
+            + [
+                self.btn_shape,
+                self.btn_undo,
+                self.btn_eraser,
+                self.btn_clear_all,
+                self.btn_whiteboard,
+                self.btn_settings,
+            ]
         )
         for btn in buttons:
-            btn.setIconSize(QSize(20, 20))
+            btn.setIconSize(QSize(18, 18))
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
             btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
             button_row.addWidget(btn)
@@ -558,27 +695,31 @@ class FloatingToolbar(QWidget):
 
         tooltip_text = {
             self.btn_cursor: "光标",
-            self.btn_brush: "画笔",
             self.btn_shape: "图形",
+            self.btn_undo: "撤销",
             self.btn_eraser: "橡皮",
             self.btn_clear_all: "清除",
             self.btn_whiteboard: "白板（单击开关 / 双击换色）",
             self.btn_settings: "画笔设置",
         }
+        for button in brush_buttons:
+            tooltip_text[button] = button.toolTip() or "画笔"
         for btn, tip_text in tooltip_text.items():
             btn.setToolTip(tip_text)
             btn.installEventFilter(self)
 
         self.tool_buttons = QButtonGroup(self)
-        for btn in (self.btn_cursor, self.btn_brush, self.btn_shape, self.btn_eraser):
+        for btn in (self.btn_cursor, *brush_buttons, self.btn_shape, self.btn_eraser):
             btn.setCheckable(True)
             self.tool_buttons.addButton(btn)
         self.tool_buttons.setExclusive(True)
 
         self.btn_cursor.clicked.connect(lambda: self.overlay.set_mode("cursor"))
-        self.btn_brush.clicked.connect(lambda: self.overlay.set_mode("brush"))
+        for color_hex, button in zip([c for c, _ in brush_configs], brush_buttons):
+            button.clicked.connect(lambda _checked, c=color_hex: self.overlay.use_brush_color(c))
         self.btn_shape.clicked.connect(self._select_shape)
-        self.btn_eraser.clicked.connect(lambda: self.overlay.set_mode("eraser"))
+        self.btn_undo.clicked.connect(self.overlay.undo_last_action)
+        self.btn_eraser.clicked.connect(self._toggle_eraser)
         self.btn_clear_all.clicked.connect(self.overlay.clear_all)
         self.btn_settings.clicked.connect(self.overlay.open_pen_settings)
         self.btn_whiteboard.clicked.connect(self._handle_whiteboard_click)
@@ -589,8 +730,39 @@ class FloatingToolbar(QWidget):
         # 使用单次定时器来区分白板按钮的单击与双击行为
         self._wb_click_timer.timeout.connect(self.overlay.toggle_whiteboard)
 
+        self.btn_undo.setEnabled(False)
+
         for widget in (self, container, self.title_bar):
             widget.installEventFilter(self)
+
+    def _toggle_eraser(self) -> None:
+        if self.overlay.mode == "eraser":
+            self.overlay.restore_previous_brush()
+        else:
+            self.overlay.set_mode("eraser")
+
+    def update_tool_states(self, mode: str, pen_color: QColor) -> None:
+        color_key = pen_color.name().lower()
+        for hex_key, button in self.brush_color_buttons.items():
+            prev = button.blockSignals(True)
+            button.setChecked(mode == "brush" and hex_key == color_key)
+            button.blockSignals(prev)
+        for tool, button in (
+            ("cursor", self.btn_cursor),
+            ("shape", self.btn_shape),
+            ("eraser", self.btn_eraser),
+        ):
+            prev = button.blockSignals(True)
+            button.setChecked(mode == tool)
+            button.blockSignals(prev)
+        if mode == "brush" and color_key not in self.brush_color_buttons:
+            for button in (self.btn_cursor, self.btn_shape, self.btn_eraser):
+                prev = button.blockSignals(True)
+                button.setChecked(False)
+                button.blockSignals(prev)
+
+    def update_undo_state(self, enabled: bool) -> None:
+        self.btn_undo.setEnabled(enabled)
 
     def eventFilter(self, obj, event):
         event_type = event.type()
@@ -643,6 +815,8 @@ class OverlayWindow(QWidget):
         s = self.settings_manager.load_settings().get("Paint", {})
         self.pen_size = int(s.get("brush_size", "12"))
         self.pen_color = QColor(s.get("brush_color", "#ff0000"))
+        self._last_brush_color = QColor(self.pen_color)
+        self._last_pen_size = self.pen_size
         self.mode = "brush"
         self.current_shape: Optional[str] = None
         self.shape_start_point: Optional[QPoint] = None
@@ -656,8 +830,11 @@ class OverlayWindow(QWidget):
         self.setMouseTracking(True)
 
         self._build_scene()
+        self.history: List[QPixmap] = []
+        self._history_limit = 30
         self.toolbar = FloatingToolbar(self, self.settings_manager)
         self.set_mode("brush", initial=True)
+        self.toolbar.update_undo_state(False)
 
     def raise_toolbar(self) -> None:
         if getattr(self, "toolbar", None) is not None:
@@ -685,6 +862,9 @@ class OverlayWindow(QWidget):
         d = PenSettingsDialog(self.toolbar, self.pen_size, self.pen_color.name())
         if d.exec():
             self.pen_size, self.pen_color = d.get_settings()
+            self.last_width = self.pen_size * 0.4
+            self.last_time = time.time()
+            self._remember_brush_state()
             self.update_cursor()
         self.set_mode(pm, ps)
         self.raise_toolbar()
@@ -711,6 +891,9 @@ class OverlayWindow(QWidget):
         self.update()
 
     def set_mode(self, mode: str, shape_type: Optional[str] = None, *, initial: bool = False) -> None:
+        previous_mode = getattr(self, "mode", None)
+        if previous_mode == "brush" and mode != "brush":
+            self._remember_brush_state()
         self.mode = mode
         if shape_type is not None or mode != "shape":
             self.current_shape = shape_type
@@ -721,13 +904,14 @@ class OverlayWindow(QWidget):
             self.raise_toolbar()
         self.update_toolbar_state()
         self.update_cursor()
+        if self.mode == "brush":
+            self.last_width = self.pen_size * 0.4
+            self.last_time = time.time()
 
     def update_toolbar_state(self) -> None:
         if not getattr(self, 'toolbar', None):
             return
-        m = {"cursor": self.toolbar.btn_cursor, "brush": self.toolbar.btn_brush, "shape": self.toolbar.btn_shape, "eraser": self.toolbar.btn_eraser}
-        for k, b in m.items():
-            prev = b.blockSignals(True); b.setChecked(self.mode == k); b.blockSignals(prev)
+        self.toolbar.update_tool_states(self.mode, self.pen_color)
 
     def update_cursor(self) -> None:
         if self.mode == "cursor":
@@ -764,11 +948,71 @@ class OverlayWindow(QWidget):
             if not self.isVisible():
                 self.show()
 
+    def _push_history(self) -> None:
+        if not isinstance(self.canvas, QPixmap):
+            return
+        self.history.append(self.canvas.copy())
+        if len(self.history) > self._history_limit:
+            self.history.pop(0)
+        self._update_undo_button()
+
+    def _update_undo_button(self) -> None:
+        if getattr(self, "toolbar", None):
+            self.toolbar.update_undo_state(bool(self.history))
+
+    def _remember_brush_state(self) -> None:
+        self._last_brush_color = QColor(self.pen_color)
+        self._last_pen_size = self.pen_size
+
+    def restore_previous_brush(self) -> None:
+        if self._last_brush_color and isinstance(self._last_brush_color, QColor) and self._last_brush_color.isValid():
+            self.pen_color = QColor(self._last_brush_color)
+        if isinstance(self._last_pen_size, int) and self._last_pen_size > 0:
+            self.pen_size = self._last_pen_size
+        self.last_width = self.pen_size * 0.4
+        self.last_time = time.time()
+        if self.mode != "brush":
+            self.set_mode("brush")
+        else:
+            self.update_toolbar_state()
+            self.update_cursor()
+        self._remember_brush_state()
+
     def clear_all(self) -> None:
+        self._push_history()
         self.canvas.fill(Qt.GlobalColor.transparent)
         self.temp_canvas.fill(Qt.GlobalColor.transparent)
         self.update()
         self.raise_toolbar()
+        self._update_undo_button()
+        self.restore_previous_brush()
+
+    def use_brush_color(self, color_hex: str) -> None:
+        color = QColor(color_hex)
+        if not color.isValid():
+            return
+        self.pen_color = color
+        self.last_width = self.pen_size * 0.4
+        self.last_time = time.time()
+        self._remember_brush_state()
+        self.set_mode("brush")
+
+    def undo_last_action(self) -> None:
+        if not self.history:
+            return
+        last = self.history.pop()
+        if isinstance(last, QPixmap):
+            self.canvas = last
+        else:
+            self._update_undo_button()
+            return
+        self.temp_canvas.fill(Qt.GlobalColor.transparent)
+        self.drawing = False
+        self.last_time = time.time()
+        self.last_width = self.pen_size * 0.4
+        self.update()
+        self.raise_toolbar()
+        self._update_undo_button()
 
     def save_settings(self) -> None:
         settings = self.settings_manager.load_settings()
@@ -789,9 +1033,13 @@ class OverlayWindow(QWidget):
     # ---- 画图事件 ----
     def mousePressEvent(self, e) -> None:
         if e.button() == Qt.MouseButton.LeftButton and self.mode != "cursor":
+            self._push_history()
             self.drawing = True
-            pointf = e.position(); self.last_point = pointf; self.prev_point = pointf
+            pointf = QPointF(e.position())
+            self.last_point = QPointF(pointf)
+            self.prev_point = QPointF(pointf)
             self.last_width = self.pen_size * 0.4
+            self.last_time = time.time()
             self.shape_start_point = e.pos() if self.mode == "shape" else None
             self.raise_toolbar()
             e.accept()
@@ -834,21 +1082,48 @@ class OverlayWindow(QWidget):
         mid = (self.last_point + cur) / 2.0
 
         path = QPainterPath(); path.moveTo(self.prev_point); path.quadTo(self.last_point, mid)
-        p = QPainter(self.canvas); p.setRenderHint(QPainter.RenderHint.Antialiasing)
-        fade = QColor(self.pen_color); fade.setAlpha(70)
-        p.setPen(QPen(fade, cur_w * 1.4, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)); p.drawPath(path)
-        p.setPen(QPen(self.pen_color, cur_w, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)); p.drawPath(path)
-        p.end()
+        painter = QPainter(self.canvas)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        fade = QColor(self.pen_color)
+        fade.setAlpha(90)
+        painter.setPen(QPen(fade, cur_w * 1.45, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin))
+        painter.drawPath(path)
 
-        self.prev_point = self.last_point; self.last_point = cur; self.last_width = cur_w
+        main_pen = QPen(self.pen_color, cur_w, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(main_pen)
+        painter.drawPath(path)
+
+        highlight_color = QColor(self.pen_color)
+        highlight_color = highlight_color.lighter(130)
+        highlight_color.setAlpha(160)
+        highlight_pen = QPen(highlight_color, max(1.0, cur_w * 0.45), Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
+        highlight_path = QPainterPath()
+        highlight_path.moveTo(self.last_point)
+        highlight_mid = QPointF(
+            self.last_point.x() * 0.6 + mid.x() * 0.4,
+            self.last_point.y() * 0.6 + mid.y() * 0.4,
+        )
+        highlight_path.quadTo(highlight_mid, mid)
+        painter.setPen(highlight_pen)
+        painter.drawPath(highlight_path)
+        painter.end()
+
+        self.prev_point = QPointF(self.last_point)
+        self.last_point = QPointF(cur)
+        self.last_width = cur_w
 
     def _erase_at(self, pos) -> None:
-        if isinstance(pos, QPointF): pos = pos.toPoint()
-        p = QPainter(self.canvas); p.setRenderHint(QPainter.RenderHint.Antialiasing)
-        p.setCompositionMode(QPainter.CompositionMode.CompositionMode_Clear)
-        radius = max(6, int(self.pen_size * 3.2))
-        p.setPen(QPen(QColor(255, 255, 255, 0), radius, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin))
-        p.drawPoint(pos); p.end()
+        current = QPointF(pos) if not isinstance(pos, QPointF) else QPointF(pos)
+        painter = QPainter(self.canvas)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_Clear)
+        radius = max(8.0, float(self.pen_size) * 2.6)
+        eraser_pen = QPen(QColor(255, 255, 255, 0), radius, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(eraser_pen)
+        painter.drawLine(self.last_point, current)
+        painter.end()
+        self.prev_point = QPointF(self.last_point)
+        self.last_point = QPointF(current)
 
     def _draw_shape_preview(self, end_point) -> None:
         if not self.shape_start_point: return
@@ -1026,7 +1301,13 @@ class RollCallTimerWindow(QWidget):
 
         s = self.settings_manager.load_settings().get("RollCallTimer", {})
         apply_geometry_from_text(self, s.get("geometry", "420x240+180+180"))
-        self.setMinimumSize(260, 160)
+        available = _available_geometry(self)
+        if available:
+            min_width = max(260, int(available.width() * 0.2))
+            min_height = max(160, int(available.height() * 0.2))
+        else:
+            min_width, min_height = 260, 160
+        self.setMinimumSize(min_width, min_height)
 
         self.mode = s.get("mode", "roll_call") if s.get("mode", "roll_call") in {"roll_call", "timer"} else "roll_call"
         self.timer_modes = ["countdown", "stopwatch", "clock"]
@@ -1315,6 +1596,7 @@ class RollCallTimerWindow(QWidget):
             if not self.show_id: self.id_label.setText("")
             if not self.show_name: self.name_label.setText("")
         self.update_display_layout()
+        self.update_dynamic_fonts()
 
     def update_display_layout(self) -> None:
         self.id_label.setVisible(self.show_id); self.name_label.setVisible(self.show_name)
@@ -1458,16 +1740,16 @@ class LauncherWindow(QWidget):
             """
             QWidget#launcherContainer {
                 background-color: rgba(28, 29, 32, 232);
-                border-radius: 10px;
-                border: 1px solid rgba(255, 255, 255, 45);
+                border-radius: 9px;
+                border: 1px solid rgba(255, 255, 255, 40);
             }
             QPushButton {
                 color: #f1f3f4;
                 background-color: rgba(60, 64, 67, 230);
-                border: 1px solid rgba(255, 255, 255, 30);
+                border: 1px solid rgba(255, 255, 255, 35);
                 border-radius: 6px;
-                padding: 4px 10px;
-                min-height: 28px;
+                padding: 3px 9px;
+                min-height: 26px;
             }
             QPushButton:hover {
                 background-color: rgba(138, 180, 248, 240);
@@ -1493,19 +1775,19 @@ class LauncherWindow(QWidget):
         )
         container = QWidget(self); container.setObjectName("launcherContainer")
         layout = QVBoxLayout(self); layout.setContentsMargins(0, 0, 0, 0); layout.addWidget(container)
-        v = QVBoxLayout(container); v.setContentsMargins(10, 10, 10, 10); v.setSpacing(6)
+        v = QVBoxLayout(container); v.setContentsMargins(8, 8, 8, 8); v.setSpacing(5)
 
-        row = QHBoxLayout(); row.setSpacing(4)
+        row = QHBoxLayout(); row.setSpacing(3)
         self.paint_button = QPushButton("画笔"); self.paint_button.clicked.connect(self.toggle_paint); row.addWidget(self.paint_button)
         self.roll_call_button = QPushButton("点名/计时"); self.roll_call_button.clicked.connect(self.toggle_roll_call); row.addWidget(self.roll_call_button)
         v.addLayout(row)
 
-        bottom = QHBoxLayout(); bottom.setSpacing(4)
+        bottom = QHBoxLayout(); bottom.setSpacing(3)
         self.autostart_check = QCheckBox("开机启动"); self.autostart_check.stateChanged.connect(self.toggle_autostart); bottom.addWidget(self.autostart_check)
 
-        right = QHBoxLayout(); right.setSpacing(4)
-        self.about_button = QPushButton("关于"); self.about_button.setFixedWidth(44); self.about_button.clicked.connect(self.show_about); right.addWidget(self.about_button)
-        self.exit_button = QPushButton("退出"); self.exit_button.setFixedWidth(44)
+        right = QHBoxLayout(); right.setSpacing(3)
+        self.about_button = QPushButton("关于"); self.about_button.setFixedWidth(42); self.about_button.clicked.connect(self.show_about); right.addWidget(self.about_button)
+        self.exit_button = QPushButton("退出"); self.exit_button.setFixedWidth(42)
         self.exit_button.clicked.connect(QApplication.instance().quit)
         right.addWidget(self.exit_button)
         bottom.addLayout(right); v.addLayout(bottom)
@@ -1527,6 +1809,8 @@ class LauncherWindow(QWidget):
         # 锁定启动器的推荐尺寸，避免误拖拽造成遮挡
         self.adjustSize()
         self.setFixedSize(self.sizeHint())
+        pos = _clamp_widget_position(self, self.x(), self.y())
+        self.move(pos)
 
     def eventFilter(self, obj, e) -> bool:
         if e.type() == QEvent.Type.MouseButtonPress and e.button() == Qt.MouseButton.LeftButton:


### PR DESCRIPTION
## Summary
- replace static eraser/clear glyphs with dynamically drawn icons and tighten toolbar placement across screens
- remember and restore the previous brush state so clearing or toggling the eraser drops back to the teacher's pen settings while smoothing brush/eraser strokes
- clamp window geometry to the active display and refresh roll call typography to react immediately when text changes

## Testing
- python -m py_compile ClassroomTools.py

------
https://chatgpt.com/codex/tasks/task_e_68e07b5cbe5c832c863182b8953c18d1