### PR TITLE
Fix roll call history persistence

### DIFF
--- a/ClassroomTools.py
+++ b/ClassroomTools.py
@@ -529,7 +529,7 @@ class SettingsManager:
         self._settings_cache = {section: values.copy() for section, values in snapshot.items()}
 
     def clear_roll_call_history(self) -> None:
-        """清空点名相关的历史记录，保证新启动时重新开始。"""
+        """清除点名历史信息，仅在用户主动重置时调用。"""
 
         settings = self.load_settings()
         section = settings.get("RollCallTimer", {})
@@ -1932,6 +1932,7 @@ class RollCallTimerWindow(QWidget):
     def _reset_roll_call_state(self) -> None:
         """清空全部点名历史并重新洗牌。"""
 
+        self.settings_manager.clear_roll_call_history()
         self._rebuild_group_indices()
         self._ensure_group_pool(self.current_group_name)
 
@@ -2971,8 +2972,6 @@ class LauncherWindow(QWidget):
             self.bubble.close()
         if self.roll_call_window is not None: self.roll_call_window.close()
         if self.overlay is not None: self.overlay.close()
-        # 启动器关闭视为重新开课，清理点名历史以便下次全新开始
-        self.settings_manager.clear_roll_call_history()
         super().closeEvent(e)
 
 
@@ -2985,8 +2984,6 @@ def main() -> None:
     QToolTip.setFont(QFont("Microsoft YaHei UI", 9))
 
     settings_manager = SettingsManager()
-    # 每次启动器运行时先清空上一轮的点名记录，确保不会延续上一课堂的名单
-    settings_manager.clear_roll_call_history()
     student_data = load_student_data(None) if PANDAS_AVAILABLE else None
 
     window = LauncherWindow(settings_manager, student_data)


### PR DESCRIPTION
## Summary
- stop clearing roll call history when the launcher opens or closes so unfinished sessions persist
- trigger history clearing only during an explicit full reset and keep the helper docstring in sync

## Testing
- python -m py_compile ClassroomTools.py

------
https://chatgpt.com/codex/tasks/task_e_68e32cd90120832c97918caff4895b7f