### PR TITLE
Improve dialog styling and defer encrypted prompts

### DIFF
--- a/ClassroomTools.py
+++ b/ClassroomTools.py
@@ -63,7 +63,6 @@ from PyQt6.QtWidgets import (
     QFrame,
     QGridLayout,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QMenu,
@@ -462,7 +461,7 @@ class QuietInfoPopup(QWidget):
         apply_button_style(
             self.ok_button,
             ButtonStyles.PRIMARY,
-            height=recommended_control_height(self.ok_button.font(), extra=12, minimum=34),
+            height=recommended_control_height(self.ok_button.font(), extra=14, minimum=36),
         )
         self.ok_button.clicked.connect(self.close)
         button_row.addWidget(self.ok_button)
@@ -529,7 +528,7 @@ class QuietQuestionDialog(QDialog):
         buttons.addStretch(1)
 
         cancel = QPushButton("取消", self)
-        control_height = recommended_control_height(cancel.font(), extra=12, minimum=34)
+        control_height = recommended_control_height(cancel.font(), extra=14, minimum=36)
         apply_button_style(cancel, ButtonStyles.TOOLBAR, height=control_height)
         cancel.clicked.connect(self.reject)
         buttons.addWidget(cancel)
@@ -540,12 +539,75 @@ class QuietQuestionDialog(QDialog):
         ok.clicked.connect(self.accept)
         buttons.addWidget(ok)
 
+        target_width = max(cancel.sizeHint().width(), ok.sizeHint().width())
+        cancel.setFixedWidth(target_width)
+        ok.setFixedWidth(target_width)
+
         layout.addLayout(buttons)
         self._ok_button = ok
 
     def showEvent(self, event) -> None:  # type: ignore[override]
         super().showEvent(event)
         self._ok_button.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
+
+
+class PasswordPromptDialog(QDialog):
+    """统一样式的密码输入窗口，确保按钮始终可见且尺寸一致。"""
+
+    def __init__(self, parent: Optional[QWidget], title: str, prompt: str) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setModal(True)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 18, 24, 18)
+        layout.setSpacing(12)
+
+        label = QLabel(prompt, self)
+        label.setWordWrap(True)
+        label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(label)
+
+        self.line_edit = QLineEdit(self)
+        self.line_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.line_edit.setMinimumWidth(220)
+        layout.addWidget(self.line_edit)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            Qt.Orientation.Horizontal,
+            self,
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        style_dialog_buttons(
+            button_box,
+            {
+                QDialogButtonBox.StandardButton.Ok: ButtonStyles.PRIMARY,
+                QDialogButtonBox.StandardButton.Cancel: ButtonStyles.TOOLBAR,
+            },
+            extra_padding=12,
+            minimum_height=34,
+            uniform_width=True,
+        )
+        layout.addWidget(button_box)
+
+        self.line_edit.returnPressed.connect(self.accept)
+
+    @classmethod
+    def get_password(
+        cls, parent: Optional[QWidget], title: str, prompt: str
+    ) -> tuple[str, bool]:
+        dialog = cls(parent, title, prompt)
+        accepted = dialog.exec() == QDialog.DialogCode.Accepted
+        value = dialog.line_edit.text() if accepted else ""
+        return value, accepted
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
+        self.line_edit.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
 
 
 def ask_quiet_confirmation(parent: Optional[QWidget], text: str, title: str = "确认") -> bool:
@@ -557,7 +619,10 @@ def recommended_control_height(font: QFont, *, extra: int = 12, minimum: int = 3
     """Return a DPI-aware button height based on the supplied font metrics."""
 
     metrics = QFontMetrics(font)
-    return max(minimum, metrics.height() + extra)
+    text_height = metrics.boundingRect("Ag").height()
+    line_height = metrics.height()
+    base_height = max(text_height, line_height)
+    return max(minimum, int(math.ceil(base_height + extra)))
 
 
 class ButtonStyles:
@@ -565,7 +630,7 @@ class ButtonStyles:
 
     TOOLBAR = (
         "QPushButton {\n"
-        "    padding: 4px 14px;\n"
+        "    padding: 4px 12px;\n"
         "    border-radius: 12px;\n"
         "    border: 1px solid #c4c8d0;\n"
         "    background-color: #ffffff;\n"
@@ -592,7 +657,7 @@ class ButtonStyles:
 
     GRID = (
         "QPushButton {\n"
-        "    padding: 6px 14px;\n"
+        "    padding: 6px 12px;\n"
         "    border-radius: 10px;\n"
         "    border: 1px solid #c4c8d0;\n"
         "    background-color: #ffffff;\n"
@@ -609,7 +674,7 @@ class ButtonStyles:
 
     PRIMARY = (
         "QPushButton {\n"
-        "    padding: 6px 22px;\n"
+        "    padding: 6px 20px;\n"
         "    border-radius: 20px;\n"
         "    background-color: #1a73e8;\n"
         "    color: #ffffff;\n"
@@ -656,7 +721,34 @@ def apply_button_style(button: QPushButton, style: str, *, height: Optional[int]
     if height is not None:
         button.setMinimumHeight(height)
         button.setMaximumHeight(height)
+        button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
     button.setStyleSheet(style)
+
+
+def style_dialog_buttons(
+    button_box: QDialogButtonBox,
+    styles: Mapping[QDialogButtonBox.StandardButton, str],
+    *,
+    extra_padding: int = 10,
+    minimum_height: int = 34,
+    uniform_width: bool = False,
+) -> None:
+    """Apply shared styling to all buttons contained in a QDialogButtonBox."""
+
+    styled_buttons: list[QPushButton] = []
+    for standard_button, style in styles.items():
+        button = button_box.button(standard_button)
+        if button is None:
+            continue
+        control_height = recommended_control_height(
+            button.font(), extra=extra_padding, minimum=minimum_height
+        )
+        apply_button_style(button, style, height=control_height)
+        styled_buttons.append(button)
+    if uniform_width and styled_buttons:
+        target_width = max(button.sizeHint().width() for button in styled_buttons)
+        for button in styled_buttons:
+            button.setFixedWidth(target_width)
 
 
 # ---------- 配置 ----------
@@ -920,17 +1012,15 @@ class PenSettingsDialog(QDialog):
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
-        for standard, style in (
-            (QDialogButtonBox.StandardButton.Ok, ButtonStyles.PRIMARY),
-            (QDialogButtonBox.StandardButton.Cancel, ButtonStyles.TOOLBAR),
-        ):
-            button = buttons.button(standard)
-            if button is not None:
-                apply_button_style(
-                    button,
-                    style,
-                    height=recommended_control_height(button.font(), extra=10, minimum=32),
-                )
+        style_dialog_buttons(
+            buttons,
+            {
+                QDialogButtonBox.StandardButton.Ok: ButtonStyles.PRIMARY,
+                QDialogButtonBox.StandardButton.Cancel: ButtonStyles.TOOLBAR,
+            },
+            extra_padding=10,
+            minimum_height=32,
+        )
         layout.addWidget(buttons)
 
         self.setFixedSize(self.sizeHint())
@@ -2008,17 +2098,15 @@ class CountdownSettingsDialog(QDialog):
 
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         buttons.accepted.connect(self._accept); buttons.rejected.connect(self.reject)
-        for standard, style in (
-            (QDialogButtonBox.StandardButton.Ok, ButtonStyles.PRIMARY),
-            (QDialogButtonBox.StandardButton.Cancel, ButtonStyles.TOOLBAR),
-        ):
-            button = buttons.button(standard)
-            if button is not None:
-                apply_button_style(
-                    button,
-                    style,
-                    height=recommended_control_height(button.font(), extra=12, minimum=34),
-                )
+        style_dialog_buttons(
+            buttons,
+            {
+                QDialogButtonBox.StandardButton.Ok: ButtonStyles.PRIMARY,
+                QDialogButtonBox.StandardButton.Cancel: ButtonStyles.TOOLBAR,
+            },
+            extra_padding=12,
+            minimum_height=34,
+        )
         layout.addWidget(buttons)
         self.setFixedSize(self.sizeHint())
 
@@ -2110,7 +2198,7 @@ class StudentListDialog(QDialog):
             apply_button_style(
                 close_button,
                 ButtonStyles.PRIMARY,
-                height=recommended_control_height(close_button.font(), extra=12, minimum=36),
+                height=recommended_control_height(close_button.font(), extra=14, minimum=36),
             )
         layout.addWidget(box)
 
@@ -3188,27 +3276,27 @@ class RollCallTimerWindow(QWidget):
         self.mode_button.setFont(mode_font)
         fm = self.mode_button.fontMetrics()
         max_text = max(("切换到计时", "切换到点名"), key=lambda t: fm.horizontalAdvance(t))
-        target_width = fm.horizontalAdvance(max_text) + 24
-        self.mode_button.setFixedWidth(target_width)  # 固定宽度，避免文本切换导致按钮位置跳动
-        self.mode_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        control_height = recommended_control_height(mode_font, extra=12, minimum=34)
+        target_width = fm.horizontalAdvance(max_text) + 28
+        self.mode_button.setMinimumWidth(target_width)
+        self.mode_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        control_height = recommended_control_height(mode_font, extra=14, minimum=36)
         apply_button_style(self.mode_button, ButtonStyles.TOOLBAR, height=control_height)
         self.mode_button.clicked.connect(self.toggle_mode)
         top.addWidget(self.mode_button, 0, Qt.AlignmentFlag.AlignLeft)
 
         compact_font = QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium)
-        toolbar_height = recommended_control_height(compact_font, extra=12, minimum=34)
+        toolbar_height = recommended_control_height(compact_font, extra=14, minimum=36)
 
         def _setup_secondary_button(button: QPushButton) -> None:
             apply_button_style(button, ButtonStyles.TOOLBAR, height=toolbar_height)
-            button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+            button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
             button.setFont(compact_font)
 
         control_bar = QWidget()
-        control_bar.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        control_bar.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         control_layout = QHBoxLayout(control_bar)
         control_layout.setContentsMargins(0, 0, 0, 0)
-        control_layout.setSpacing(4)
+        control_layout.setSpacing(2)
 
         self.list_button = QPushButton("名单"); _setup_secondary_button(self.list_button)
         self.list_button.clicked.connect(self.show_student_selector)
@@ -3238,7 +3326,7 @@ class RollCallTimerWindow(QWidget):
 
         group_row = QHBoxLayout()
         group_row.setContentsMargins(0, 0, 0, 0)
-        group_row.setSpacing(4)
+        group_row.setSpacing(2)
 
         self.group_label = QLabel("分组")
         self.group_label.setFont(QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium))
@@ -3248,22 +3336,33 @@ class RollCallTimerWindow(QWidget):
         self.group_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         group_row.addWidget(self.group_label, 0, Qt.AlignmentFlag.AlignLeft)
 
-        self.group_bar = QWidget()
+        group_container = QWidget()
+        group_container.setFixedHeight(toolbar_height)
+        group_container.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        group_container_layout = QHBoxLayout(group_container)
+        group_container_layout.setContentsMargins(0, 0, 0, 0)
+        group_container_layout.setSpacing(0)
+
+        self.group_container = group_container
+
+        self.group_bar = QWidget(group_container)
         self.group_bar.setFixedHeight(toolbar_height)
-        self.group_bar.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self.group_bar.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.group_bar_layout = QHBoxLayout(self.group_bar)
         self.group_bar_layout.setContentsMargins(0, 0, 0, 0)
-        self.group_bar_layout.setSpacing(2)
+        self.group_bar_layout.setSpacing(1)
         self.group_button_group = QButtonGroup(self)
         self.group_button_group.setExclusive(True)
         self.group_buttons: Dict[str, QPushButton] = {}
         self._rebuild_group_buttons_ui()
-        group_row.addWidget(self.group_bar, 1, Qt.AlignmentFlag.AlignLeft)
+        group_container_layout.addWidget(self.group_bar, 1, Qt.AlignmentFlag.AlignLeft)
 
         self.add_score_button = QPushButton("加分"); _setup_secondary_button(self.add_score_button)
         self.add_score_button.setEnabled(False)
         self.add_score_button.clicked.connect(self.increment_current_score)
-        group_row.addWidget(self.add_score_button, 0, Qt.AlignmentFlag.AlignLeft)
+        group_container_layout.addWidget(self.add_score_button, 0, Qt.AlignmentFlag.AlignLeft)
+
+        group_row.addWidget(group_container, 1, Qt.AlignmentFlag.AlignLeft)
         group_row.addStretch(1)
         toolbar_layout.addLayout(group_row)
         layout.addLayout(toolbar_layout)
@@ -3298,14 +3397,14 @@ class RollCallTimerWindow(QWidget):
         self.time_display_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         tl.addWidget(self.time_display_label, 1)
 
-        ctrl = QHBoxLayout(); ctrl.setSpacing(6)
+        ctrl = QHBoxLayout(); ctrl.setSpacing(4)
         self.timer_mode_button = QPushButton("倒计时"); self.timer_mode_button.clicked.connect(self.toggle_timer_mode)
         self.timer_start_pause_button = QPushButton("开始"); self.timer_start_pause_button.clicked.connect(self.start_pause_timer)
         self.timer_reset_button = QPushButton("重置"); self.timer_reset_button.clicked.connect(self.reset_timer)
         self.timer_set_button = QPushButton("设定"); self.timer_set_button.clicked.connect(self.set_countdown_time)
         for b in (self.timer_mode_button, self.timer_start_pause_button, self.timer_reset_button, self.timer_set_button):
             b.setFont(compact_font)
-        timer_height = recommended_control_height(compact_font, extra=12, minimum=34)
+        timer_height = recommended_control_height(compact_font, extra=14, minimum=36)
         for b in (self.timer_mode_button, self.timer_start_pause_button, self.timer_reset_button, self.timer_set_button):
             apply_button_style(b, ButtonStyles.TOOLBAR, height=timer_height)
             b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
@@ -3339,11 +3438,10 @@ class RollCallTimerWindow(QWidget):
     def _prompt_new_encryption_password(self) -> Optional[str]:
         attempts = 0
         while attempts < 3:
-            password, ok = QInputDialog.getText(
+            password, ok = PasswordPromptDialog.get_password(
                 self,
                 "设置加密密码",
                 "请输入新的加密密码：",
-                QLineEdit.EchoMode.Password,
             )
             if not ok:
                 return None
@@ -3352,11 +3450,10 @@ class RollCallTimerWindow(QWidget):
                 show_quiet_information(self, "密码不能为空，请重新输入。")
                 attempts += 1
                 continue
-            confirm, ok = QInputDialog.getText(
+            confirm, ok = PasswordPromptDialog.get_password(
                 self,
                 "确认加密密码",
                 "请再次输入密码以确认：",
-                QLineEdit.EchoMode.Password,
             )
             if not ok:
                 return None
@@ -3372,11 +3469,10 @@ class RollCallTimerWindow(QWidget):
     def _prompt_existing_encryption_password(self, title: str) -> Optional[str]:
         attempts = 0
         while attempts < 3:
-            password, ok = QInputDialog.getText(
+            password, ok = PasswordPromptDialog.get_password(
                 self,
                 title,
                 "请输入当前的加密密码：",
-                QLineEdit.EchoMode.Password,
             )
             if not ok:
                 return None
@@ -3915,8 +4011,12 @@ class RollCallTimerWindow(QWidget):
         self.title_label.setText("点名" if is_roll else "计时")
         self.mode_button.setText("切换到计时" if is_roll else "切换到点名")
         self.group_label.setVisible(is_roll)
+        if hasattr(self, "group_container"):
+            self.group_container.setVisible(is_roll)
         if hasattr(self, "group_bar"):
             self.group_bar.setVisible(is_roll)
+        if hasattr(self, "add_score_button"):
+            self.add_score_button.setVisible(is_roll)
         self._update_roll_call_controls()
         if is_roll:
             if self._placeholder_on_show:
@@ -4574,7 +4674,7 @@ class RollCallTimerWindow(QWidget):
         if not self.groups:
             return
         button_font = QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium)
-        button_height = recommended_control_height(button_font, extra=12, minimum=34)
+        button_height = recommended_control_height(button_font, extra=14, minimum=36)
         for group in self.groups:
             button = QPushButton(group)
             button.setCheckable(True)
@@ -5025,11 +5125,10 @@ def load_student_data(parent: Optional[QWidget]) -> Optional[pd.DataFrame]:
     if not os.path.exists(file_path) and os.path.exists(encrypted_path):
         attempts = 0
         while attempts < 3:
-            password, ok = QInputDialog.getText(
+            password, ok = PasswordPromptDialog.get_password(
                 parent,
                 "解密学生数据",
                 "检测到已加密的学生名单，请输入密码：",
-                QLineEdit.EchoMode.Password,
             )
             if not ok:
                 QMessageBox.information(parent, "提示", "已取消加载加密的学生名单。")
@@ -5313,7 +5412,7 @@ class LauncherWindow(QWidget):
         self.autostart_check.setChecked(autostart_enabled and WINREG_AVAILABLE)
         self.autostart_check.setEnabled(WINREG_AVAILABLE)
 
-        if not PANDAS_AVAILABLE or not OPENPYXL_AVAILABLE or self.student_data is None:
+        if not (PANDAS_AVAILABLE and OPENPYXL_AVAILABLE):
             self.roll_call_button.setEnabled(False)
 
         for w in (self, container, self.paint_button, self.roll_call_button, self.minimize_button, self.autostart_check):
@@ -5585,7 +5684,9 @@ def main() -> None:
     QToolTip.setFont(QFont("Microsoft YaHei UI", 9))
 
     settings_manager = SettingsManager()
-    student_data = load_student_data(None) if PANDAS_AVAILABLE else None
+    student_data = load_student_data(None) if PANDAS_AVAILABLE and not os.path.exists(
+        RollCallTimerWindow.ENCRYPTED_STUDENT_FILE
+    ) else None
 
     window = LauncherWindow(settings_manager, student_data)
     app.aboutToQuit.connect(window.handle_about_to_quit)


### PR DESCRIPTION
## Summary
- add a reusable password dialog and update confirmation styles so critical OK/Cancel buttons render immediately with matching sizes
- refit the roll call toolbar so the group buttons and “加分” control sit flush while maintaining consistent visibility when switching modes
- defer encrypted student password prompts until the roll call view is requested while still allowing unencrypted data to preload

## Testing
- python -m compileall ClassroomTools.py

------
https://chatgpt.com/codex/tasks/task_e_68e497aed760832c9915035c65b6aca7