### PR TITLE
Add class selector and workbook support for roll call

### DIFF
--- a/ClassroomTools.py
+++ b/ClassroomTools.py
@@ -29,6 +29,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Mapping,
     Optional,
@@ -208,6 +209,14 @@ if TYPE_CHECKING:
     from pandas import DataFrame as PandasDataFrame
 else:  # pragma: no cover - runtime fallback for typing
     PandasDataFrame = Any  # type: ignore[misc, assignment]
+
+
+@dataclass
+class StudentWorkbook:
+    """代表 students.xlsx 中的所有班级工作表。"""
+
+    sheets: Dict[str, PandasDataFrame]
+    active_sheet: str
 
 if sys.platform == "win32":
     try:
@@ -700,6 +709,15 @@ class PasswordPromptDialog(QDialog):
         self.line_edit.setMinimumWidth(220)
         layout.addWidget(self.line_edit)
 
+        self.error_label = QLabel("", self)
+        self.error_label.setWordWrap(True)
+        self.error_label.setObjectName("passwordPromptErrorLabel")
+        self.error_label.setStyleSheet(
+            "#passwordPromptErrorLabel { color: #d93025; font-size: 12px; margin-top: 4px; }"
+        )
+        self.error_label.hide()
+        layout.addWidget(self.error_label)
+
         button_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
             Qt.Orientation.Horizontal,
@@ -720,12 +738,19 @@ class PasswordPromptDialog(QDialog):
         layout.addWidget(button_box)
 
         self.line_edit.returnPressed.connect(self.accept)
+        self.line_edit.textChanged.connect(self._clear_error)
 
     @classmethod
     def get_password(
-        cls, parent: Optional[QWidget], title: str, prompt: str
+        cls,
+        parent: Optional[QWidget],
+        title: str,
+        prompt: str,
+        *,
+        allow_empty: bool = True,
     ) -> tuple[str, bool]:
         dialog = cls(parent, title, prompt)
+        dialog._allow_empty = allow_empty  # type: ignore[attr-defined]
         accepted = dialog.exec() == QDialog.DialogCode.Accepted
         value = dialog._captured_text if accepted else ""
         return value, accepted
@@ -735,12 +760,140 @@ class PasswordPromptDialog(QDialog):
         self.line_edit.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
 
     def accept(self) -> None:  # type: ignore[override]
-        self._captured_text = self.line_edit.text()
+        text = self.line_edit.text()
+        if not getattr(self, "_allow_empty", True) and not text.strip():
+            self._show_error("密码不能为空，请重新输入。")
+            return
+        self._captured_text = text
         super().accept()
 
     def reject(self) -> None:  # type: ignore[override]
         self._captured_text = ""
         super().reject()
+
+    def _show_error(self, message: str) -> None:
+        self.error_label.setText(message)
+        self.error_label.show()
+        self.line_edit.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
+
+    def _clear_error(self, _: str) -> None:
+        if self.error_label.isVisible():
+            self.error_label.hide()
+
+
+class PasswordSetupDialog(QDialog):
+    """一次性采集两次输入的新密码，避免外部循环引发界面阻塞。"""
+
+    def __init__(self, parent: Optional[QWidget], title: str, prompt: str, confirm_prompt: str) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setModal(True)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
+        self._password: str = ""
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 18, 24, 18)
+        layout.setSpacing(12)
+
+        prompt_label = QLabel(prompt, self)
+        prompt_label.setWordWrap(True)
+        prompt_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(prompt_label)
+
+        self.password_edit = QLineEdit(self)
+        self.password_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.password_edit.setMinimumWidth(220)
+        layout.addWidget(self.password_edit)
+
+        confirm_label = QLabel(confirm_prompt, self)
+        confirm_label.setWordWrap(True)
+        confirm_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(confirm_label)
+
+        self.confirm_edit = QLineEdit(self)
+        self.confirm_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.confirm_edit.setMinimumWidth(220)
+        layout.addWidget(self.confirm_edit)
+
+        self.error_label = QLabel("", self)
+        self.error_label.setWordWrap(True)
+        self.error_label.setObjectName("passwordSetupErrorLabel")
+        self.error_label.setStyleSheet(
+            "#passwordSetupErrorLabel { color: #d93025; font-size: 12px; margin-top: 4px; }"
+        )
+        self.error_label.hide()
+        layout.addWidget(self.error_label)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            Qt.Orientation.Horizontal,
+            self,
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        style_dialog_buttons(
+            button_box,
+            {
+                QDialogButtonBox.StandardButton.Ok: ButtonStyles.PRIMARY,
+                QDialogButtonBox.StandardButton.Cancel: ButtonStyles.TOOLBAR,
+            },
+            extra_padding=12,
+            minimum_height=34,
+            uniform_width=True,
+        )
+        layout.addWidget(button_box)
+
+        self.password_edit.returnPressed.connect(self._focus_confirm)
+        self.confirm_edit.returnPressed.connect(self.accept)
+        self.password_edit.textChanged.connect(self._clear_error)
+        self.confirm_edit.textChanged.connect(self._clear_error)
+
+    @classmethod
+    def get_new_password(
+        cls,
+        parent: Optional[QWidget],
+        title: str,
+        prompt: str,
+        confirm_prompt: str,
+    ) -> tuple[str, bool]:
+        dialog = cls(parent, title, prompt, confirm_prompt)
+        accepted = dialog.exec() == QDialog.DialogCode.Accepted
+        value = dialog._password if accepted else ""
+        return value, accepted
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
+        self.password_edit.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
+
+    def accept(self) -> None:  # type: ignore[override]
+        password = self.password_edit.text().strip()
+        confirm = self.confirm_edit.text().strip()
+        if not password:
+            self._show_error("密码不能为空，请重新输入。", focus_widget=self.password_edit)
+            return
+        if password != confirm:
+            self._show_error("两次输入的密码不一致，请重新设置。", focus_widget=self.confirm_edit)
+            return
+        self._password = password
+        super().accept()
+
+    def reject(self) -> None:  # type: ignore[override]
+        self._password = ""
+        super().reject()
+
+    def _show_error(self, message: str, *, focus_widget: Optional[QWidget] = None) -> None:
+        self.error_label.setText(message)
+        self.error_label.show()
+        target = focus_widget or self.password_edit
+        target.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
+
+    def _clear_error(self, _: str) -> None:
+        if self.error_label.isVisible():
+            self.error_label.hide()
+
+    def _focus_confirm(self) -> None:
+        self.confirm_edit.setFocus(Qt.FocusReason.TabFocusReason)
 
 
 def ask_quiet_confirmation(parent: Optional[QWidget], text: str, title: str = "确认") -> bool:
@@ -758,13 +911,27 @@ def recommended_control_height(font: QFont, *, extra: int = 12, minimum: int = 3
     return max(minimum, int(math.ceil(base_height + extra)))
 
 
+def _clone_dataframe(df: PandasDataFrame) -> PandasDataFrame:
+    """Return a defensive copy of *df* while兼容非标准对象。"""
+
+    if not (PANDAS_AVAILABLE and pd is not None):
+        return df
+    try:
+        return df.copy()
+    except Exception:
+        return pd.DataFrame(df)
+
+
+WorkbookPayload = Union[PandasDataFrame, StudentWorkbook, Dict[str, PandasDataFrame]]
+
+
 class ButtonStyles:
     """Centralised QPushButton样式，避免各窗口重复定义造成视觉不一致。"""
 
     TOOLBAR = (
         "QPushButton {\n"
-        "    padding: 4px 12px;\n"
-        "    border-radius: 12px;\n"
+        "    padding: 3px 10px;\n"
+        "    border-radius: 10px;\n"
         "    border: 1px solid #c4c8d0;\n"
         "    background-color: #ffffff;\n"
         "    color: #202124;\n"
@@ -1156,7 +1323,8 @@ class PenSettingsDialog(QDialog):
         )
         layout.addWidget(buttons)
 
-        self.setFixedSize(self.sizeHint())
+        hint = self.sizeHint()
+        self.setFixedSize(hint.width(), hint.height() + 12)
 
     def _select_color(self, color_hex: str) -> None:
         self.pen_color = QColor(color_hex)
@@ -3428,7 +3596,7 @@ class RollCallTimerWindow(QWidget):
     def __init__(
         self,
         settings_manager: SettingsManager,
-        student_data,
+        student_workbook: Optional[StudentWorkbook],
         parent: Optional[QWidget] = None,
         *,
         defer_password_prompt: bool = False,
@@ -3446,25 +3614,28 @@ class RollCallTimerWindow(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.settings_manager = settings_manager
         self._encrypted_file_path = self.ENCRYPTED_STUDENT_FILE
-        base_dataframe = student_data
-        if isinstance(base_dataframe, pd.DataFrame):
-            pass
-        elif base_dataframe is None and PANDAS_AVAILABLE and pd is not None:
-            base_dataframe = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
-        self.student_data = base_dataframe
+        self.student_data: Optional[PandasDataFrame] = None
+        self._active_workbook: Optional[StudentWorkbook] = student_workbook
+        self._class_sheets: Dict[str, PandasDataFrame] = {}
         self._student_data_pending_load = False
         encrypted_state, encrypted_password = _get_session_student_encryption()
         self._student_file_encrypted = bool(encrypted_state)
         self._student_password = encrypted_password
         if defer_password_prompt:
-            base_empty = not isinstance(self.student_data, pd.DataFrame) or getattr(self.student_data, "empty", True)
+            base_empty = True
+            if self._active_workbook is not None:
+                base_empty = not any(
+                    isinstance(df, pd.DataFrame) and not getattr(df, "empty", True)
+                    for df in self._active_workbook.sheets.values()
+                )
             if base_empty:
                 has_plain = os.path.exists(self.STUDENT_FILE)
                 has_encrypted = os.path.exists(self._encrypted_file_path)
                 if has_plain or has_encrypted:
                     self._student_data_pending_load = True
-                    if not isinstance(self.student_data, pd.DataFrame) and PANDAS_AVAILABLE and pd is not None:
-                        self.student_data = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
+                    if self._active_workbook is None and PANDAS_AVAILABLE and pd is not None:
+                        empty_df = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
+                        self._active_workbook = StudentWorkbook({"1班": empty_df}, "1班")
         try:
             self._rng = random.SystemRandom()
         except NotImplementedError:
@@ -3499,6 +3670,7 @@ class RollCallTimerWindow(QWidget):
 
         self.current_group_name = s.get("current_group", "全部")
         self.groups = ["全部"]
+        self.current_class_name = s.get("current_class", "")
 
         self.current_student_index: Optional[int] = None
         self._placeholder_on_show = True
@@ -3545,6 +3717,7 @@ class RollCallTimerWindow(QWidget):
         self._pending_passive_student: Optional[int] = None
         self._score_persist_failed = False
         self._score_write_lock = threading.Lock()
+        self._class_menu: Optional[QMenu] = None
 
         # QFontDatabase 在 Qt 6 中以静态方法为主，这里直接调用类方法避免实例化失败
         families_list = []
@@ -3568,7 +3741,7 @@ class RollCallTimerWindow(QWidget):
         self._save_timer.timeout.connect(self.save_settings)
 
         self._build_ui()
-        self._set_student_dataframe(self.student_data, propagate=False)
+        self._apply_student_workbook(self._active_workbook, propagate=False)
         self._apply_saved_fonts()
         self._update_menu_state()
         self._restore_group_state(s)
@@ -3581,7 +3754,7 @@ class RollCallTimerWindow(QWidget):
         self.setStyleSheet("background-color: #f4f5f7;")
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(6)
+        layout.setSpacing(5)
 
         toolbar_layout = QVBoxLayout()
         toolbar_layout.setContentsMargins(0, 0, 0, 0)
@@ -3589,7 +3762,7 @@ class RollCallTimerWindow(QWidget):
 
         top = QHBoxLayout()
         top.setContentsMargins(0, 0, 0, 0)
-        top.setSpacing(4)
+        top.setSpacing(3)
         self.title_label = QLabel("点名"); f = QFont("Microsoft YaHei UI", 10, QFont.Weight.Bold)
         self.title_label.setFont(f); self.title_label.setStyleSheet("color: #202124;")
         self.title_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
@@ -3603,13 +3776,13 @@ class RollCallTimerWindow(QWidget):
         target_width = fm.horizontalAdvance(max_text) + 28
         self.mode_button.setMinimumWidth(target_width)
         self.mode_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        control_height = recommended_control_height(mode_font, extra=14, minimum=36)
+        control_height = recommended_control_height(mode_font, extra=10, minimum=34)
         apply_button_style(self.mode_button, ButtonStyles.TOOLBAR, height=control_height)
         self.mode_button.clicked.connect(self.toggle_mode)
         top.addWidget(self.mode_button, 0, Qt.AlignmentFlag.AlignLeft)
 
         compact_font = QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium)
-        toolbar_height = recommended_control_height(compact_font, extra=14, minimum=36)
+        toolbar_height = recommended_control_height(compact_font, extra=10, minimum=34)
 
         def _setup_secondary_button(button: QPushButton) -> None:
             apply_button_style(button, ButtonStyles.TOOLBAR, height=toolbar_height)
@@ -3620,11 +3793,11 @@ class RollCallTimerWindow(QWidget):
         control_bar.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         control_layout = QHBoxLayout(control_bar)
         control_layout.setContentsMargins(0, 0, 0, 0)
-        control_layout.setSpacing(2)
+        control_layout.setSpacing(1)
 
-        self.list_button = QPushButton("名单"); _setup_secondary_button(self.list_button)
-        self.list_button.clicked.connect(self.show_student_selector)
-        control_layout.addWidget(self.list_button)
+        self.class_button = QPushButton("班级"); _setup_secondary_button(self.class_button)
+        self.class_button.clicked.connect(self.show_class_selector)
+        control_layout.addWidget(self.class_button)
 
         self.showcase_button = QPushButton("展示"); _setup_secondary_button(self.showcase_button)
         self.showcase_button.clicked.connect(self.show_scoreboard)
@@ -3665,7 +3838,7 @@ class RollCallTimerWindow(QWidget):
         group_container.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         group_container_layout = QHBoxLayout(group_container)
         group_container_layout.setContentsMargins(0, 0, 0, 0)
-        group_container_layout.setSpacing(0)
+        group_container_layout.setSpacing(1)
 
         self.group_container = group_container
 
@@ -3680,6 +3853,10 @@ class RollCallTimerWindow(QWidget):
         self.group_buttons: Dict[str, QPushButton] = {}
         self._rebuild_group_buttons_ui()
         group_container_layout.addWidget(self.group_bar, 1, Qt.AlignmentFlag.AlignLeft)
+
+        self.list_button = QPushButton("名单"); _setup_secondary_button(self.list_button)
+        self.list_button.clicked.connect(self.show_student_selector)
+        group_container_layout.addWidget(self.list_button, 0, Qt.AlignmentFlag.AlignLeft)
 
         self.add_score_button = QPushButton("加分"); _setup_secondary_button(self.add_score_button)
         self.add_score_button.setEnabled(False)
@@ -3760,35 +3937,16 @@ class RollCallTimerWindow(QWidget):
             self._handle_encrypt_student_file()
 
     def _prompt_new_encryption_password(self) -> Optional[str]:
-        attempts = 0
-        while attempts < 3:
-            password, ok = PasswordPromptDialog.get_password(
-                self,
-                "设置加密密码",
-                "请输入新的加密密码：",
-            )
-            if not ok:
-                return None
-            password = password.strip()
-            if not password:
-                show_quiet_information(self, "密码不能为空，请重新输入。")
-                attempts += 1
-                continue
-            confirm, ok = PasswordPromptDialog.get_password(
-                self,
-                "确认加密密码",
-                "请再次输入密码以确认：",
-            )
-            if not ok:
-                return None
-            confirm = confirm.strip()
-            if password != confirm:
-                show_quiet_information(self, "两次输入的密码不一致，请重新设置。")
-                attempts += 1
-                continue
-            return password
-        show_quiet_information(self, "未能成功设置密码，已取消加密操作。")
-        return None
+        password, ok = PasswordSetupDialog.get_new_password(
+            self,
+            "设置加密密码",
+            "请输入新的加密密码：",
+            "请再次输入密码以确认：",
+        )
+        if not ok or not password:
+            show_quiet_information(self, "未能成功设置密码，已取消加密操作。")
+            return None
+        return password
 
     def _prompt_existing_encryption_password(self, title: str) -> Optional[str]:
         attempts = 0
@@ -3797,6 +3955,7 @@ class RollCallTimerWindow(QWidget):
                 self,
                 title,
                 "请输入当前的加密密码：",
+                allow_empty=False,
             )
             if not ok:
                 return None
@@ -3808,6 +3967,123 @@ class RollCallTimerWindow(QWidget):
             return password
         show_quiet_information(self, "密码输入次数过多，操作已取消。")
         return None
+
+    def _apply_student_workbook(
+        self,
+        workbook: Optional[StudentWorkbook],
+        *,
+        propagate: bool,
+    ) -> None:
+        if not (PANDAS_AVAILABLE and pd is not None):
+            self.student_data = None
+            self._class_sheets = {}
+            self._update_class_button()
+            self._update_roll_call_controls()
+            return
+
+        self._active_workbook = workbook
+        if workbook is None or not workbook.sheets:
+            placeholder = self.current_class_name or "1班"
+            empty_df = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
+            self._class_sheets = {placeholder: empty_df}
+            self.current_class_name = placeholder
+            self._set_student_dataframe(empty_df, propagate=propagate)
+            self._update_class_button()
+            return
+
+        self._class_sheets = {name: _clone_dataframe(df) for name, df in workbook.sheets.items()}
+        target = self.current_class_name or workbook.active_sheet
+        if target not in self._class_sheets:
+            if workbook.active_sheet in self._class_sheets:
+                target = workbook.active_sheet
+            else:
+                target = next(iter(self._class_sheets))
+        self.current_class_name = target
+        active_df = _clone_dataframe(self._class_sheets[target])
+        self._set_student_dataframe(active_df, propagate=propagate)
+        self._update_class_button()
+
+    def _attach_workbook_metadata(self) -> None:
+        if not (PANDAS_AVAILABLE and pd is not None):
+            return
+        if not isinstance(self.student_data, pd.DataFrame):
+            return
+        if not self.current_class_name:
+            if self._class_sheets:
+                self.current_class_name = next(iter(self._class_sheets))
+            else:
+                self.current_class_name = "1班"
+        if self.current_class_name:
+            self._class_sheets[self.current_class_name] = _clone_dataframe(self.student_data)
+        workbook_copy = {name: _clone_dataframe(df) for name, df in self._class_sheets.items()}
+        self.student_data.attrs["workbook_sheets"] = workbook_copy
+        self.student_data.attrs["active_sheet"] = self.current_class_name
+        self._active_workbook = StudentWorkbook(workbook_copy, self.current_class_name)
+
+    def _update_class_button(self) -> None:
+        if not hasattr(self, "class_button"):
+            return
+        label = self.current_class_name or "未选择"
+        self.class_button.setText(f"班级：{label}")
+        enabled = self.mode == "roll_call" and bool(self._class_sheets) and not self._student_data_pending_load
+        self.class_button.setEnabled(enabled)
+
+    def _store_current_class_snapshot(self) -> None:
+        if not (PANDAS_AVAILABLE and pd is not None):
+            return
+        if not isinstance(self.student_data, pd.DataFrame):
+            return
+        if not self.current_class_name:
+            return
+        self._class_sheets[self.current_class_name] = _clone_dataframe(self.student_data)
+
+    def _export_current_workbook(self) -> Optional[StudentWorkbook]:
+        if not (PANDAS_AVAILABLE and pd is not None):
+            return None
+        if not self._class_sheets:
+            return None
+        sheets = {name: _clone_dataframe(df) for name, df in self._class_sheets.items()}
+        active = self.current_class_name if self.current_class_name in sheets else next(iter(sheets))
+        return StudentWorkbook(sheets=sheets, active_sheet=active)
+
+    def export_student_workbook(self) -> Optional[StudentWorkbook]:
+        """对外暴露的工作簿导出接口，供启动器同步最新数据。"""
+
+        return self._export_current_workbook()
+
+    def show_class_selector(self) -> None:
+        if self.mode != "roll_call":
+            return
+        if self._student_data_pending_load and not self._load_student_data_if_needed():
+            return
+        if not self._class_sheets:
+            show_quiet_information(self, "暂无班级数据可供选择。")
+            return
+        menu = QMenu(self.class_button)
+        menu.setSeparatorsCollapsible(False)
+        current = self.current_class_name
+        for name in sorted(self._class_sheets.keys()):
+            act = menu.addAction(name)
+            act.setCheckable(True)
+            act.setChecked(name == current)
+            act.triggered.connect(lambda _checked, n=name: self._switch_class(n))
+        self._class_menu = menu  # 防止局部变量被垃圾回收
+        pos = self.class_button.mapToGlobal(self.class_button.rect().bottomLeft())
+        menu.exec(pos)
+        self._class_menu = None
+
+    def _switch_class(self, class_name: str) -> None:
+        if class_name == self.current_class_name:
+            return
+        if class_name not in self._class_sheets:
+            show_quiet_information(self, "未找到目标班级。")
+            return
+        self._store_current_class_snapshot()
+        target_df = _clone_dataframe(self._class_sheets[class_name])
+        self.current_class_name = class_name
+        self._set_student_dataframe(target_df, propagate=True)
+        self.display_current_student()
+        self._schedule_save()
 
     def _set_student_dataframe(self, df: Optional[PandasDataFrame], *, propagate: bool = True) -> None:
         if not (PANDAS_AVAILABLE and pd is not None):
@@ -3842,19 +4118,22 @@ class RollCallTimerWindow(QWidget):
         self._ensure_group_pool(self.current_group_name, force_reset=True)
         self.current_student_index = None
         self._pending_passive_student = None
+        self._attach_workbook_metadata()
         if propagate:
             self._propagate_student_dataframe()
+        self._update_roll_call_controls()
+        self._update_class_button()
 
     def _load_student_data_if_needed(self) -> bool:
         if not self._student_data_pending_load:
             return True
         if not (PANDAS_AVAILABLE and OPENPYXL_AVAILABLE):
             return False
-        df = load_student_data(self)
-        if df is None:
+        workbook = load_student_data(self)
+        if workbook is None:
             return False
         self._student_data_pending_load = False
-        self._set_student_dataframe(df, propagate=True)
+        self._apply_student_workbook(workbook, propagate=True)
         encrypted_state, encrypted_password = _get_session_student_encryption()
         self._student_file_encrypted = bool(encrypted_state)
         self._student_password = encrypted_password
@@ -3875,13 +4154,18 @@ class RollCallTimerWindow(QWidget):
         if self.student_data is None:
             show_quiet_information(self, "没有可加密的学生数据。")
             return
-        try:
-            df = self.student_data.copy()
-        except Exception:
-            df = pd.DataFrame(self.student_data)
+        payload: WorkbookPayload
+        workbook_payload = self._export_current_workbook()
+        if workbook_payload is not None:
+            payload = workbook_payload
+        else:
+            try:
+                payload = self.student_data.copy()
+            except Exception:
+                payload = pd.DataFrame(self.student_data)
         try:
             _save_student_workbook(
-                df,
+                payload,
                 self.STUDENT_FILE,
                 self._encrypted_file_path,
                 encrypted=True,
@@ -3916,14 +4200,14 @@ class RollCallTimerWindow(QWidget):
             return
         try:
             buffer = io.BytesIO(plain_bytes)
-            df = pd.read_excel(buffer)
-            df = _normalize_student_dataframe(df, drop_incomplete=False)
+            sheet_frames = pd.read_excel(buffer, sheet_name=None)
+            workbook = _build_student_workbook(sheet_frames, drop_incomplete=False)
         except Exception as exc:
             show_quiet_information(self, f"读取解密后的学生数据失败：{exc}")
             return
         try:
             _save_student_workbook(
-                df,
+                workbook,
                 self.STUDENT_FILE,
                 self._encrypted_file_path,
                 encrypted=False,
@@ -3935,24 +4219,33 @@ class RollCallTimerWindow(QWidget):
         self._student_file_encrypted = False
         self._student_password = None
         _set_session_student_encryption(False, None)
-        self._apply_decrypted_student_data(df)
+        self._apply_decrypted_student_data(workbook)
         self._update_encryption_button()
         show_quiet_information(self, "已成功解密学生数据并恢复 students.xlsx。")
         self._schedule_save()
 
-    def _apply_decrypted_student_data(self, df: PandasDataFrame) -> None:
+    def _apply_decrypted_student_data(self, workbook: StudentWorkbook) -> None:
         if not (PANDAS_AVAILABLE and pd is not None):
             return
-        self._set_student_dataframe(df, propagate=True)
+        self._apply_student_workbook(workbook, propagate=True)
         self.display_current_student()
 
     def _propagate_student_dataframe(self) -> None:
         parent = self.parent()
-        if parent is not None and hasattr(parent, "student_data"):
-            try:
-                setattr(parent, "student_data", self.student_data)
-            except Exception:
-                pass
+        workbook = self._export_current_workbook()
+        if parent is not None:
+            if hasattr(parent, "student_data"):
+                try:
+                    setattr(parent, "student_data", self.student_data)
+                except Exception:
+                    pass
+            if workbook is not None and hasattr(parent, "student_workbook"):
+                try:
+                    setattr(parent, "student_workbook", workbook)
+                except Exception:
+                    pass
+        if workbook is not None:
+            self._active_workbook = workbook
 
     def _apply_saved_fonts(self) -> None:
         id_font = QFont("Microsoft YaHei UI", self.last_id_font_size, QFont.Weight.Bold)
@@ -4302,10 +4595,15 @@ class RollCallTimerWindow(QWidget):
             return
         try:
             with self._score_write_lock:
-                df = self.student_data.copy()
-                df = _normalize_student_dataframe(df, drop_incomplete=False)
+                self._store_current_class_snapshot()
+                workbook = self._export_current_workbook()
+                payload: WorkbookPayload
+                if workbook is not None:
+                    payload = workbook
+                else:
+                    payload = _normalize_student_dataframe(self.student_data.copy(), drop_incomplete=False)
                 _save_student_workbook(
-                    df,
+                    payload,
                     self.STUDENT_FILE,
                     self._encrypted_file_path,
                     encrypted=self._student_file_encrypted,
@@ -4339,6 +4637,8 @@ class RollCallTimerWindow(QWidget):
             self.group_container.setVisible(is_roll)
         if hasattr(self, "group_bar"):
             self.group_bar.setVisible(is_roll)
+        if hasattr(self, "class_button"):
+            self.class_button.setVisible(is_roll)
         if hasattr(self, "add_score_button"):
             self.add_score_button.setVisible(is_roll)
         self._update_roll_call_controls()
@@ -4568,6 +4868,31 @@ class RollCallTimerWindow(QWidget):
         except Exception:
             random.shuffle(values)
 
+    def _normalize_indices(self, values: Iterable[Any], *, allowed: Optional[Set[int]] = None) -> List[int]:
+        """Convert an iterable of values to a deduplicated integer list."""
+
+        normalized: List[int] = []
+        seen: Set[int] = set()
+        for value in values:
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                continue
+            if allowed is not None and idx not in allowed:
+                continue
+            if idx in seen:
+                continue
+            normalized.append(idx)
+            seen.add(idx)
+        return normalized
+
+    def _collect_base_indices(self, values: Optional[Iterable[Any]]) -> List[int]:
+        """Normalize the raw index list preserved in each group."""
+
+        if values is None:
+            return []
+        return self._normalize_indices(values)
+
     def reset_roll_call_pools(self) -> None:
         """根据当前分组执行重置：子分组独立重置，“全部”重置所有。"""
 
@@ -4600,12 +4925,7 @@ class RollCallTimerWindow(QWidget):
         base_indices_raw = self._group_all_indices.get(group_name)
         if base_indices_raw is None:
             return
-        base_indices: List[int] = []
-        for value in base_indices_raw:
-            try:
-                base_indices.append(int(value))
-            except (TypeError, ValueError):
-                continue
+        base_indices = self._collect_base_indices(base_indices_raw)
         shuffled = list(base_indices)
         self._shuffle(shuffled)
         self._group_remaining_indices[group_name] = shuffled
@@ -4736,20 +5056,11 @@ class RollCallTimerWindow(QWidget):
         for group, indices in remaining_data.items():
             if group not in self._group_all_indices:
                 continue
-            base_list = self._group_all_indices[group]
+            base_list = self._collect_base_indices(self._group_all_indices[group])
             base_set = set(base_list)
             restored: List[int] = []
             if isinstance(indices, list):
-                seen: set[int] = set()
-                for value in indices:
-                    try:
-                        idx = int(value)
-                    except (TypeError, ValueError):
-                        continue
-                    if idx not in base_set or idx in seen:
-                        continue
-                    restored.append(idx)
-                    seen.add(idx)
+                restored = self._normalize_indices(indices, allowed=base_set)
             self._group_remaining_indices[group] = restored
 
         for group, value in last_data.items():
@@ -4768,18 +5079,8 @@ class RollCallTimerWindow(QWidget):
         # 根据恢复后的剩余名单推导出每个分组已点名的学生集合
         # 重新整理所有分组的已点名学生，并同步更新全局集合
         for group, base_indices in self._group_all_indices.items():
-            normalized_base: List[int] = []
-            for value in base_indices:
-                try:
-                    normalized_base.append(int(value))
-                except (TypeError, ValueError):
-                    continue
-            remaining_set: set[int] = set()
-            for value in self._group_remaining_indices.get(group, []):
-                try:
-                    remaining_set.add(int(value))
-                except (TypeError, ValueError):
-                    continue
+            normalized_base = self._collect_base_indices(base_indices)
+            remaining_set = set(self._normalize_indices(self._group_remaining_indices.get(group, [])))
             drawn = {idx for idx in normalized_base if idx not in remaining_set}
             if group != "全部" and existing_global:
                 # 在恢复时合并先前记录的全局名单，防止由于意外写入丢失导致遗漏
@@ -4829,12 +5130,7 @@ class RollCallTimerWindow(QWidget):
             self._shuffle(shuffled)
             self._group_initial_sequences[group_name] = shuffled
 
-        base_indices: List[int] = []
-        for value in self._group_all_indices.get(group_name, []):
-            try:
-                base_indices.append(int(value))
-            except (TypeError, ValueError):
-                continue
+        base_indices = self._collect_base_indices(self._group_all_indices.get(group_name, []))
         if group_name == "全部":
             drawn_history = self._group_drawn_history.setdefault("全部", self._global_drawn_students)
             reference_drawn = self._global_drawn_students
@@ -4939,37 +5235,82 @@ class RollCallTimerWindow(QWidget):
     def _refresh_all_group_pool(self) -> None:
         """同步“全部”分组的剩余名单，使其与各子分组保持一致。"""
 
-        base_all = self._group_all_indices.get("全部", [])
-        if "全部" not in self._group_initial_sequences:
-            shuffled = list(base_all)
+        base_all_list = self._collect_base_indices(self._group_all_indices.get("全部", []))
+        base_all_set = set(base_all_list)
+
+        subgroup_base: Dict[str, Tuple[List[int], Set[int]]] = {}
+        subgroup_remaining: Dict[str, List[int]] = {}
+        subgroup_remaining_union: Set[int] = set()
+        drawn_from_subgroups: Set[int] = set()
+
+        for group, raw_indices in self._group_all_indices.items():
+            if group == "全部":
+                continue
+            base_list = self._collect_base_indices(raw_indices)
+            base_set = set(base_list)
+            subgroup_base[group] = (base_list, base_set)
+            pool = self._group_remaining_indices.get(group, [])
+            sanitized = self._normalize_indices(pool, allowed=base_set)
+            if sanitized != pool:
+                self._group_remaining_indices[group] = sanitized
+            subgroup_remaining[group] = sanitized
+            subgroup_remaining_union.update(sanitized)
+            drawn_from_subgroups.update(idx for idx in base_set if idx not in sanitized)
+            initial = self._group_initial_sequences.get(group)
+            if initial is None:
+                self._group_initial_sequences[group] = list(base_list)
+            else:
+                cleaned_initial = self._normalize_indices(initial, allowed=base_set)
+                if cleaned_initial != list(initial):
+                    self._group_initial_sequences[group] = cleaned_initial
+                for idx in base_list:
+                    if idx not in self._group_initial_sequences[group]:
+                        self._group_initial_sequences[group].append(idx)
+
+        valid_global = {
+            idx
+            for idx in self._global_drawn_students
+            if idx in base_all_set and idx not in subgroup_remaining_union
+        }
+        new_global = {idx for idx in drawn_from_subgroups if idx in base_all_set}
+        new_global.update(valid_global)
+
+        self._global_drawn_students = set(new_global)
+        self._group_drawn_history["全部"] = self._global_drawn_students
+
+        for group, (base_list, base_set) in subgroup_base.items():
+            pool = subgroup_remaining.get(group, [])
+            filtered = [idx for idx in pool if idx in base_set and idx not in self._global_drawn_students]
+            if filtered != pool:
+                self._group_remaining_indices[group] = filtered
+                subgroup_remaining[group] = filtered
+            drawn_set = {idx for idx in base_set if idx not in filtered}
+            self._group_drawn_history[group] = drawn_set
+
+        order_hint = self._group_initial_sequences.get("全部")
+        if order_hint is None:
+            shuffled = list(base_all_list)
             self._shuffle(shuffled)
-            self._group_initial_sequences["全部"] = shuffled
-        order = list(self._group_initial_sequences.get("全部", []))
-        normalized: List[int] = []
-        seen: set[int] = set()
-        for value in order:
-            try:
-                idx = int(value)
-            except (TypeError, ValueError):
+            order_hint = shuffled
+        else:
+            cleaned_all = self._normalize_indices(order_hint, allowed=base_all_set)
+            if cleaned_all != list(order_hint):
+                order_hint = cleaned_all
+            else:
+                order_hint = list(order_hint)
+            for idx in base_all_list:
+                if idx not in order_hint:
+                    order_hint.append(idx)
+        self._group_initial_sequences["全部"] = list(order_hint)
+
+        normalized_all = [idx for idx in order_hint if idx not in self._global_drawn_students]
+        seen_all: Set[int] = set(normalized_all)
+        for idx in base_all_list:
+            if idx in seen_all or idx in self._global_drawn_students:
                 continue
-            if idx in seen:
-                continue
-            seen.add(idx)
-            if idx in self._global_drawn_students:
-                continue
-            normalized.append(idx)
-        for value in base_all:
-            try:
-                idx = int(value)
-            except (TypeError, ValueError):
-                continue
-            if idx in seen:
-                continue
-            seen.add(idx)
-            if idx in self._global_drawn_students:
-                continue
-            normalized.append(idx)
-        self._group_remaining_indices["全部"] = normalized
+            normalized_all.append(idx)
+            seen_all.add(idx)
+        self._group_remaining_indices["全部"] = normalized_all
 
     def display_current_student(self) -> None:
         if self.current_student_index is None:
@@ -5063,6 +5404,9 @@ class RollCallTimerWindow(QWidget):
         self.add_score_button.setEnabled(is_roll and has_student)
         self.list_button.setEnabled(is_roll and has_data)
         self.showcase_button.setEnabled(is_roll and has_data)
+        if hasattr(self, "class_button"):
+            self.class_button.setVisible(is_roll)
+            self.class_button.setEnabled(is_roll and bool(self._class_sheets) and not self._student_data_pending_load)
         if hasattr(self, "encrypt_button"):
             self.encrypt_button.setVisible(is_roll)
             self.encrypt_button.setEnabled(is_roll and has_data)
@@ -5167,6 +5511,7 @@ class RollCallTimerWindow(QWidget):
         sec["speech_enabled"] = bool_to_str(self.speech_enabled)
         sec["speech_voice_id"] = self.selected_voice_id
         sec["current_group"] = self.current_group_name
+        sec["current_class"] = self.current_class_name
         sec["timer_countdown_minutes"] = str(self.timer_countdown_minutes)
         sec["timer_countdown_seconds"] = str(self.timer_countdown_seconds)
         sec["timer_sound_enabled"] = bool_to_str(self.timer_sound_enabled)
@@ -5180,6 +5525,14 @@ class RollCallTimerWindow(QWidget):
         sec["timer_font_size"] = str(self.last_timer_font_size)
         sec["scoreboard_order"] = self.scoreboard_order
         sec["students_encrypted"] = bool_to_str(self._student_file_encrypted)
+        if self._student_data_pending_load:
+            # 在尚未加载真实名单数据时，保留磁盘上已有的未点名状态，避免误把占位空列表写回
+            # 此时直接返回，保持上一轮保存的名单信息不被覆盖。
+            settings["RollCallTimer"] = sec
+            self.settings_manager.save_settings(settings)
+            return
+
+        # 名单已经加载完成，正常序列化各分组的剩余名单及历史记录
         remaining_payload: Dict[str, List[int]] = {}
         for group, indices in self._group_remaining_indices.items():
             cleaned: List[int] = []
@@ -5352,8 +5705,33 @@ def _normalize_student_dataframe(
     return normalized
 
 
-def _write_student_workbook(file_path: str, df: PandasDataFrame) -> None:
-    data = _export_student_workbook_bytes(df)
+def _build_student_workbook(
+    sheet_frames: Mapping[str, PandasDataFrame],
+    *,
+    drop_incomplete: bool = True,
+) -> StudentWorkbook:
+    if not (PANDAS_AVAILABLE and pd is not None):
+        raise RuntimeError("pandas 未安装，无法构建学生工作簿。")
+
+    sheets: Dict[str, PandasDataFrame] = {}
+    for name, frame in sheet_frames.items():
+        key = str(name).strip() or "Sheet1"
+        try:
+            normalized = _normalize_student_dataframe(frame, drop_incomplete=drop_incomplete)
+        except Exception:
+            normalized = _normalize_student_dataframe(pd.DataFrame(frame), drop_incomplete=drop_incomplete)
+        sheets[key] = normalized
+
+    if not sheets:
+        default = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
+        sheets["1班"] = _normalize_student_dataframe(default, drop_incomplete=drop_incomplete)
+
+    active_sheet = next(iter(sheets))
+    return StudentWorkbook(sheets=sheets, active_sheet=active_sheet)
+
+
+def _write_student_workbook(file_path: str, payload: WorkbookPayload) -> None:
+    data = _export_student_workbook_bytes(payload)
     tmp_dir = os.path.dirname(os.path.abspath(file_path)) or "."
     fd, tmp_path = tempfile.mkstemp(suffix=".xlsx", dir=tmp_dir)
     try:
@@ -5365,8 +5743,8 @@ def _write_student_workbook(file_path: str, df: PandasDataFrame) -> None:
             os.remove(tmp_path)
 
 
-def _write_encrypted_student_workbook(file_path: str, df: PandasDataFrame, password: str) -> None:
-    data = _export_student_workbook_bytes(df)
+def _write_encrypted_student_workbook(file_path: str, payload: WorkbookPayload, password: str) -> None:
+    data = _export_student_workbook_bytes(payload)
     payload = _encrypt_student_bytes(password, data)
     tmp_dir = os.path.dirname(os.path.abspath(file_path)) or "."
     fd, tmp_path = tempfile.mkstemp(suffix=".enc", dir=tmp_dir)
@@ -5379,15 +5757,58 @@ def _write_encrypted_student_workbook(file_path: str, df: PandasDataFrame, passw
             os.remove(tmp_path)
 
 
-def _export_student_workbook_bytes(df: PandasDataFrame) -> bytes:
-    try:
-        export_df = _normalize_student_dataframe(df, drop_incomplete=False)
-    except Exception:
-        export_df = df.copy()
+def _export_student_workbook_bytes(payload: WorkbookPayload) -> bytes:
+    if not (PANDAS_AVAILABLE and pd is not None):
+        raise RuntimeError("pandas 未安装，无法导出学生名单。")
+
+    sheet_map: Dict[str, PandasDataFrame] = {}
+    preferred_sheet: Optional[str] = None
+
+    if isinstance(payload, StudentWorkbook):
+        for name, df in payload.sheets.items():
+            sheet_map[str(name)] = _normalize_student_dataframe(_clone_dataframe(df), drop_incomplete=False)
+        preferred_sheet = payload.active_sheet
+    elif isinstance(payload, dict):
+        for name, df in payload.items():
+            sheet_map[str(name)] = _normalize_student_dataframe(_clone_dataframe(df), drop_incomplete=False)
+    else:
+        attrs = getattr(payload, "attrs", {}) if hasattr(payload, "attrs") else {}
+        workbook_sheets = attrs.get("workbook_sheets")
+        preferred_sheet = attrs.get("active_sheet")
+        if isinstance(workbook_sheets, dict):
+            for name, df in workbook_sheets.items():
+                sheet_map[str(name)] = _normalize_student_dataframe(_clone_dataframe(df), drop_incomplete=False)
+        if preferred_sheet:
+            sheet_map[preferred_sheet] = _normalize_student_dataframe(_clone_dataframe(payload), drop_incomplete=False)
+        elif sheet_map:
+            first_key = next(iter(sheet_map))
+            sheet_map[first_key] = _normalize_student_dataframe(_clone_dataframe(payload), drop_incomplete=False)
+        else:
+            sheet_map["1班"] = _normalize_student_dataframe(_clone_dataframe(payload), drop_incomplete=False)
+
+    if not sheet_map:
+        empty_df = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
+        sheet_map["1班"] = _normalize_student_dataframe(empty_df, drop_incomplete=False)
+
+    def _sheet_order(item: tuple[str, PandasDataFrame]) -> tuple[int, str]:
+        name, _ = item
+        if preferred_sheet and name == preferred_sheet:
+            return (0, name)
+        return (1, name)
+
+    ordered_items = sorted(sheet_map.items(), key=_sheet_order)
 
     if not OPENPYXL_AVAILABLE:
         buffer = io.BytesIO()
-        export_df.to_excel(buffer, index=False)
+        try:
+            with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+                for name, df in ordered_items:
+                    df.to_excel(writer, sheet_name=name[:31] or "Sheet1", index=False)
+        except Exception:
+            buffer = io.BytesIO()
+            first_name, first_df = ordered_items[0]
+            first_df.to_excel(buffer, sheet_name=first_name[:31] or "Sheet1", index=False)
+        buffer.seek(0)
         return buffer.getvalue()
 
     try:
@@ -5395,48 +5816,85 @@ def _export_student_workbook_bytes(df: PandasDataFrame) -> bytes:
         from openpyxl.styles import Font
     except Exception:
         buffer = io.BytesIO()
-        export_df.to_excel(buffer, index=False)
+        try:
+            with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+                for name, df in ordered_items:
+                    df.to_excel(writer, sheet_name=name[:31] or "Sheet1", index=False)
+        except Exception:
+            buffer = io.BytesIO()
+            first_name, first_df = ordered_items[0]
+            first_df.to_excel(buffer, sheet_name=first_name[:31] or "Sheet1", index=False)
+        buffer.seek(0)
         return buffer.getvalue()
 
-    try:
-        workbook = Workbook()
-        worksheet = workbook.active
-        worksheet.title = "students"
+    def _sanitize_sheet(name: str, existing: Set[str]) -> str:
+        sanitized = re.sub(r"[\\/*?:\[\]]", "_", name.strip() or "Sheet1")
+        sanitized = sanitized[:31] or "Sheet1"
+        candidate = sanitized
+        index = 1
+        while candidate in existing:
+            suffix = f"_{index}"
+            candidate = (sanitized[: max(0, 31 - len(suffix))] + suffix) or "Sheet1"
+            index += 1
+        existing.add(candidate)
+        return candidate
 
-        headers = list(export_df.columns)
-        worksheet.append(headers)
+    workbook = Workbook()
+    header_font = None
+    body_font = None
+    try:
+        from openpyxl.styles import Font
+
         header_font = Font(name="等线", size=12, bold=True)
         body_font = Font(name="等线", size=12)
-        for cell in worksheet[1]:
-            cell.font = header_font
+    except Exception:
+        header_font = None
+        body_font = None
 
-        for row_values in export_df.itertuples(index=False, name=None):
+    sheet_names_in_use: Set[str] = set()
+
+    def _write_sheet(ws, df: PandasDataFrame) -> None:
+        if header_font is not None and body_font is not None:
+            headers = list(df.columns)
+            ws.append(headers)
+            for cell in ws[1]:
+                cell.font = header_font
+        else:
+            ws.append(list(df.columns))
+
+        for row_values in df.itertuples(index=False, name=None):
             normalized_row = []
             for value in row_values:
                 if pd.isna(value):
                     normalized_row.append(None)
                 else:
                     normalized_row.append(value)
-            worksheet.append(tuple(normalized_row))
+            ws.append(tuple(normalized_row))
 
-        for row in worksheet.iter_rows(min_row=2):
-            for cell in row:
-                cell.font = body_font
-                if isinstance(cell.value, str):
-                    cell.value = cell.value.strip()
+        if body_font is not None:
+            for row in ws.iter_rows(min_row=2):
+                for cell in row:
+                    cell.font = body_font
+                    if isinstance(cell.value, str):
+                        cell.value = cell.value.strip()
 
-        buffer = io.BytesIO()
-        workbook.save(buffer)
-        buffer.seek(0)
-        return buffer.getvalue()
-    except Exception:
-        buffer = io.BytesIO()
-        export_df.to_excel(buffer, index=False)
-        return buffer.getvalue()
+    first_name, first_df = ordered_items[0]
+    worksheet = workbook.active
+    worksheet.title = _sanitize_sheet(first_name, sheet_names_in_use)
+    _write_sheet(worksheet, first_df)
+
+    for name, df in ordered_items[1:]:
+        ws = workbook.create_sheet(title=_sanitize_sheet(name, sheet_names_in_use))
+        _write_sheet(ws, df)
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
 
 
 def _save_student_workbook(
-    df: PandasDataFrame,
+    payload: WorkbookPayload,
     file_path: str,
     encrypted_file_path: str,
     *,
@@ -5446,22 +5904,42 @@ def _save_student_workbook(
     if encrypted:
         if not password:
             raise ValueError("缺少加密密码")
-        _write_encrypted_student_workbook(encrypted_file_path, df, password)
+        _write_encrypted_student_workbook(encrypted_file_path, payload, password)
         with contextlib.suppress(FileNotFoundError):
             os.remove(file_path)
     else:
-        _write_student_workbook(file_path, df)
+        _write_student_workbook(file_path, payload)
         with contextlib.suppress(FileNotFoundError):
             os.remove(encrypted_file_path)
 
 
-def load_student_data(parent: Optional[QWidget]) -> Optional[PandasDataFrame]:
-    """从 students.xlsx 读取点名所需的数据，不存在时自动生成模板。"""
-    if not (PANDAS_AVAILABLE and OPENPYXL_AVAILABLE):
-        QMessageBox.warning(parent, "提示", "未安装 pandas/openpyxl，点名功能不可用。")
+def load_student_data(parent: Optional[QWidget]) -> Optional[StudentWorkbook]:
+    """从 students.xlsx 读取所有班级数据，不存在时自动生成模板。"""
+
+    if not PANDAS_AVAILABLE or pd is None:
+        QMessageBox.warning(parent, "提示", "未安装 pandas，点名功能不可用。")
         return None
+    if not OPENPYXL_AVAILABLE:
+        QMessageBox.warning(parent, "提示", "未安装 openpyxl，点名功能不可用。")
+        return None
+
     file_path = RollCallTimerWindow.STUDENT_FILE
     encrypted_path = getattr(RollCallTimerWindow, "ENCRYPTED_STUDENT_FILE", file_path + ".enc")
+
+    def _create_template() -> Optional[StudentWorkbook]:
+        try:
+            df = pd.DataFrame(
+                {"学号": [101, 102, 103], "姓名": ["张三", "李四", "王五"], "分组": ["A", "B", "A"], "成绩": [0, 0, 0]}
+            )
+            workbook = _build_student_workbook({"1班": df})
+            _write_student_workbook(file_path, workbook)
+            show_quiet_information(parent, f"未找到学生名单，已为您创建模板文件：{file_path}")
+            _set_session_student_encryption(False, None)
+            return workbook
+        except Exception as exc:
+            QMessageBox.critical(parent, "错误", f"创建模板文件失败：{exc}")
+            return None
+
     if not os.path.exists(file_path) and os.path.exists(encrypted_path):
         attempts = 0
         while attempts < 3:
@@ -5469,6 +5947,7 @@ def load_student_data(parent: Optional[QWidget]) -> Optional[PandasDataFrame]:
                 parent,
                 "解密学生数据",
                 "检测到已加密的学生名单，请输入密码：",
+                allow_empty=False,
             )
             if not ok:
                 QMessageBox.information(parent, "提示", "已取消加载加密的学生名单。")
@@ -5483,35 +5962,27 @@ def load_student_data(parent: Optional[QWidget]) -> Optional[PandasDataFrame]:
                     payload = fh.read()
                 plain_bytes = _decrypt_student_bytes(password, payload)
                 buffer = io.BytesIO(plain_bytes)
-                df = pd.read_excel(buffer)
-                df = _normalize_student_dataframe(df)
+                sheet_frames = pd.read_excel(buffer, sheet_name=None)
+                workbook = _build_student_workbook(sheet_frames)
                 _set_session_student_encryption(True, password)
-                return df
+                return workbook
             except Exception as exc:
                 attempts += 1
                 QMessageBox.warning(parent, "提示", f"解密失败：{exc}")
         QMessageBox.critical(parent, "错误", "多次输入密码失败，无法加载学生名单。")
         return None
+
     if not os.path.exists(file_path):
-        try:
-            df = pd.DataFrame(
-                {"学号": [101, 102, 103], "姓名": ["张三", "李四", "王五"], "分组": ["A", "B", "A"], "成绩": [0, 0, 0]}
-            )
-            df = _normalize_student_dataframe(df)
-            _write_student_workbook(file_path, df)
-            show_quiet_information(parent, f"未找到学生名单，已为您创建模板文件：{file_path}")
-            _set_session_student_encryption(False, None)
-        except Exception as exc:
-            QMessageBox.critical(parent, "错误", f"创建模板文件失败：{exc}")
-            return None
+        return _create_template()
+
     try:
-        df = pd.read_excel(file_path)
-        df = _normalize_student_dataframe(df)
-        _write_student_workbook(file_path, df)
+        sheet_frames = pd.read_excel(file_path, sheet_name=None)
+        workbook = _build_student_workbook(sheet_frames)
+        _write_student_workbook(file_path, workbook)
         _set_session_student_encryption(False, None)
         if os.path.exists(encrypted_path):
             show_quiet_information(parent, "检测到同时存在加密文件，将优先使用明文 students.xlsx。")
-        return df
+        return workbook
     except Exception as exc:
         QMessageBox.critical(parent, "错误", f"无法加载学生名单，请检查文件格式。\n错误：{exc}")
         return None
@@ -5632,10 +6103,19 @@ class LauncherBubble(QWidget):
 
 
 class LauncherWindow(QWidget):
-    def __init__(self, settings_manager: SettingsManager, student_data: Optional[PandasDataFrame]) -> None:
+    def __init__(
+        self,
+        settings_manager: SettingsManager,
+        student_workbook: Optional[StudentWorkbook],
+    ) -> None:
         super().__init__(None, Qt.WindowType.Tool | Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint)
         self.settings_manager = settings_manager
-        self.student_data = student_data
+        self.student_workbook = student_workbook
+        if student_workbook is not None and PANDAS_AVAILABLE and pd is not None:
+            active = student_workbook.sheets.get(student_workbook.active_sheet)
+            self.student_data = _clone_dataframe(active) if active is not None else None
+        else:
+            self.student_data = None
         self.overlay: Optional[OverlayWindow] = None
         self.roll_call_window: Optional[RollCallTimerWindow] = None
         self._dragging = False; self._drag_offset = QPoint()
@@ -5828,16 +6308,28 @@ class LauncherWindow(QWidget):
             settings = self.settings_manager.load_settings().get("RollCallTimer", {})
             initial_mode = settings.get("mode", "roll_call")
             defer_prompt = initial_mode == "timer"
-            data = self.student_data
-            if data is None and not defer_prompt:
-                data = load_student_data(self)
-                if data is None:
+            workbook = self.student_workbook
+            if workbook is None and self.student_data is not None and PANDAS_AVAILABLE and pd is not None:
+                attrs = getattr(self.student_data, "attrs", {}) if hasattr(self.student_data, "attrs") else {}
+                sheets = attrs.get("workbook_sheets")
+                active = attrs.get("active_sheet")
+                if isinstance(sheets, dict) and sheets:
+                    cloned = {name: _clone_dataframe(df) for name, df in sheets.items()}
+                    active_name = active if isinstance(active, str) and active in cloned else next(iter(cloned))
+                    workbook = StudentWorkbook(cloned, active_name)
+                    self.student_workbook = workbook
+            if workbook is None and not defer_prompt:
+                workbook = load_student_data(self)
+                if workbook is None:
                     QMessageBox.warning(self, "提示", "学生数据加载失败，无法打开点名器。")
                     return
-                self.student_data = data
+                self.student_workbook = workbook
+                if PANDAS_AVAILABLE and pd is not None:
+                    active_df = workbook.sheets.get(workbook.active_sheet)
+                    self.student_data = _clone_dataframe(active_df) if active_df is not None else None
             self.roll_call_window = RollCallTimerWindow(
                 self.settings_manager,
-                self.student_data,
+                workbook,
                 parent=self,
                 defer_password_prompt=defer_prompt,
             )
@@ -5859,6 +6351,12 @@ class LauncherWindow(QWidget):
         if window is not None:
             try:
                 self.student_data = window.student_data
+            except Exception:
+                pass
+            try:
+                workbook = window.export_student_workbook()
+                if workbook is not None:
+                    self.student_workbook = workbook
             except Exception:
                 pass
         self.roll_call_window = None
@@ -6024,11 +6522,12 @@ def main() -> None:
     QToolTip.setFont(QFont("Microsoft YaHei UI", 9))
 
     settings_manager = SettingsManager()
-    student_data = load_student_data(None) if PANDAS_AVAILABLE and not os.path.exists(
-        RollCallTimerWindow.ENCRYPTED_STUDENT_FILE
-    ) else None
+    if PANDAS_AVAILABLE and OPENPYXL_AVAILABLE and not os.path.exists(RollCallTimerWindow.ENCRYPTED_STUDENT_FILE):
+        student_workbook = load_student_data(None)
+    else:
+        student_workbook = None
 
-    window = LauncherWindow(settings_manager, student_data)
+    window = LauncherWindow(settings_manager, student_workbook)
     app.aboutToQuit.connect(window.handle_about_to_quit)
     window.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- add a StudentWorkbook abstraction so multi-class Excel workbooks load, save, and encrypt consistently
- introduce a compact class selector button in the roll-call toolbar while moving the roster control beside the score button
- refresh launcher plumbing and pen settings layout so workbook changes propagate and dialog buttons render fully

## Testing
- python -m py_compile ClassroomTools.py

------
https://chatgpt.com/codex/tasks/task_e_68e4bbc04afc832c824af5aa9ca3ada2