### PR TITLE
Refine roll call controls and pen dialog sizing

### DIFF
--- a/ClassroomTools.py
+++ b/ClassroomTools.py
@@ -930,8 +930,8 @@ class ButtonStyles:
 
     TOOLBAR = (
         "QPushButton {\n"
-        "    padding: 3px 10px;\n"
-        "    border-radius: 10px;\n"
+        "    padding: 2px 10px;\n"
+        "    border-radius: 8px;\n"
         "    border: 1px solid #c4c8d0;\n"
         "    background-color: #ffffff;\n"
         "    color: #202124;\n"
@@ -948,7 +948,7 @@ class ButtonStyles:
         "QPushButton:pressed {\n"
         "    background-color: #d7e7ff;\n"
         "}\n"
-        "QPushButton:checked {\n"
+        "QPushButton:checked, QPushButton:default {\n"
         "    background-color: #1a73e8;\n"
         "    border-color: #1a73e8;\n"
         "    color: #ffffff;\n"
@@ -957,8 +957,8 @@ class ButtonStyles:
 
     GRID = (
         "QPushButton {\n"
-        "    padding: 6px 12px;\n"
-        "    border-radius: 10px;\n"
+        "    padding: 4px 10px;\n"
+        "    border-radius: 8px;\n"
         "    border: 1px solid #c4c8d0;\n"
         "    background-color: #ffffff;\n"
         "    color: #202124;\n"
@@ -970,12 +970,16 @@ class ButtonStyles:
         "QPushButton:pressed {\n"
         "    background-color: #d7e7ff;\n"
         "}\n"
+        "QPushButton:default {\n"
+        "    border-color: #1a73e8;\n"
+        "    background-color: rgba(26, 115, 232, 0.12);\n"
+        "}\n"
     )
 
     PRIMARY = (
         "QPushButton {\n"
-        "    padding: 6px 20px;\n"
-        "    border-radius: 20px;\n"
+        "    padding: 5px 16px;\n"
+        "    border-radius: 14px;\n"
         "    background-color: #1a73e8;\n"
         "    color: #ffffff;\n"
         "    border: 1px solid #1a73e8;\n"
@@ -991,6 +995,11 @@ class ButtonStyles:
         "    background-color: #aac6ff;\n"
         "    border-color: #aac6ff;\n"
         "    color: rgba(255, 255, 255, 0.8);\n"
+        "}\n"
+        "QPushButton:default {\n"
+        "    background-color: #1a73e8;\n"
+        "    border-color: #1a73e8;\n"
+        "    color: #ffffff;\n"
         "}\n"
     )
 
@@ -1276,7 +1285,7 @@ class PenSettingsDialog(QDialog):
         self.pen_color = QColor(initial_color)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(10, 8, 10, 18)
+        layout.setContentsMargins(12, 10, 12, 12)
         layout.setSpacing(6)
 
         size_layout = QHBoxLayout()
@@ -1294,9 +1303,11 @@ class PenSettingsDialog(QDialog):
         layout.addLayout(size_layout)
 
         layout.addWidget(QLabel("颜色:"))
-        color_layout = QGridLayout()
+        color_widget = QWidget()
+        color_layout = QGridLayout(color_widget)
         color_layout.setContentsMargins(0, 0, 0, 0)
-        color_layout.setSpacing(6)
+        color_layout.setHorizontalSpacing(6)
+        color_layout.setVerticalSpacing(6)
         for index, (color_hex, name) in enumerate(self.COLORS.items()):
             button = QPushButton()
             button.setFixedSize(24, 24)
@@ -1307,7 +1318,7 @@ class PenSettingsDialog(QDialog):
             button.setToolTip(name)
             button.clicked.connect(lambda _checked, c=color_hex: self._select_color(c))
             color_layout.addWidget(button, index // 3, index % 3)
-        layout.addLayout(color_layout)
+        layout.addWidget(color_widget)
 
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         buttons.accepted.connect(self.accept)
@@ -1318,13 +1329,16 @@ class PenSettingsDialog(QDialog):
                 QDialogButtonBox.StandardButton.Ok: ButtonStyles.PRIMARY,
                 QDialogButtonBox.StandardButton.Cancel: ButtonStyles.TOOLBAR,
             },
-            extra_padding=10,
-            minimum_height=32,
+            extra_padding=8,
+            minimum_height=30,
+            uniform_width=True,
         )
         layout.addWidget(buttons)
+        if buttons.layout() is not None:
+            buttons.layout().setContentsMargins(0, 6, 0, 0)
 
-        hint = self.sizeHint()
-        self.setFixedSize(hint.width(), hint.height() + 24)
+        self.adjustSize()
+        self.setFixedSize(self.size())
 
     def _select_color(self, color_hex: str) -> None:
         self.pen_color = QColor(color_hex)
@@ -3754,7 +3768,7 @@ class RollCallTimerWindow(QWidget):
         self.setStyleSheet("background-color: #f4f5f7;")
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)
-        layout.setSpacing(5)
+        layout.setSpacing(4)
 
         toolbar_layout = QVBoxLayout()
         toolbar_layout.setContentsMargins(0, 0, 0, 0)
@@ -3762,7 +3776,7 @@ class RollCallTimerWindow(QWidget):
 
         top = QHBoxLayout()
         top.setContentsMargins(0, 0, 0, 0)
-        top.setSpacing(3)
+        top.setSpacing(2)
         self.title_label = QLabel("点名"); f = QFont("Microsoft YaHei UI", 10, QFont.Weight.Bold)
         self.title_label.setFont(f); self.title_label.setStyleSheet("color: #202124;")
         self.title_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
@@ -3773,33 +3787,35 @@ class RollCallTimerWindow(QWidget):
         self.mode_button.setFont(mode_font)
         fm = self.mode_button.fontMetrics()
         max_text = max(("切换到计时", "切换到点名"), key=lambda t: fm.horizontalAdvance(t))
-        target_width = fm.horizontalAdvance(max_text) + 28
+        target_width = fm.horizontalAdvance(max_text) + 26
         self.mode_button.setMinimumWidth(target_width)
         self.mode_button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        control_height = recommended_control_height(mode_font, extra=10, minimum=34)
+        compact_font = QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium)
+        toolbar_height = recommended_control_height(compact_font, extra=12, minimum=34)
+        self._toolbar_font = compact_font
+        self._toolbar_height = toolbar_height
+        control_height = max(toolbar_height, recommended_control_height(mode_font, extra=8, minimum=30))
         apply_button_style(self.mode_button, ButtonStyles.TOOLBAR, height=control_height)
         self.mode_button.clicked.connect(self.toggle_mode)
         top.addWidget(self.mode_button, 0, Qt.AlignmentFlag.AlignLeft)
-
-        compact_font = QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium)
-        toolbar_height = recommended_control_height(compact_font, extra=10, minimum=34)
 
         def _setup_secondary_button(button: QPushButton, *, lock_width: bool = False) -> None:
             apply_button_style(button, ButtonStyles.TOOLBAR, height=toolbar_height)
             button.setFont(compact_font)
             if lock_width:
-                hint = button.sizeHint()
-                button.setMinimumWidth(hint.width())
-                button.setMaximumWidth(max(hint.width(), button.minimumSizeHint().width()))
+                width = max(button.sizeHint().width(), button.minimumSizeHint().width())
+                button.setFixedWidth(width)
                 button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
             else:
-                button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+                button.setMinimumWidth(0)
+                button.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         control_bar = QWidget()
+        control_bar.setFixedHeight(toolbar_height)
         control_bar.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         control_layout = QHBoxLayout(control_bar)
         control_layout.setContentsMargins(0, 0, 0, 0)
-        control_layout.setSpacing(1)
+        control_layout.setSpacing(2)
 
         self.showcase_button = QPushButton("展示"); _setup_secondary_button(self.showcase_button)
         self.showcase_button.clicked.connect(self.show_scoreboard)
@@ -3827,7 +3843,10 @@ class RollCallTimerWindow(QWidget):
         top.addWidget(self.menu_button, 0, Qt.AlignmentFlag.AlignRight)
         toolbar_layout.addLayout(top)
 
-        group_row = QHBoxLayout()
+        group_row_widget = QWidget()
+        group_row_widget.setFixedHeight(toolbar_height)
+        group_row_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        group_row = QHBoxLayout(group_row_widget)
         group_row.setContentsMargins(0, 0, 0, 0)
         group_row.setSpacing(2)
 
@@ -3841,16 +3860,16 @@ class RollCallTimerWindow(QWidget):
 
         group_container = QWidget()
         group_container.setFixedHeight(toolbar_height)
-        group_container.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        group_container.setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         group_container_layout = QHBoxLayout(group_container)
         group_container_layout.setContentsMargins(0, 0, 0, 0)
-        group_container_layout.setSpacing(1)
+        group_container_layout.setSpacing(2)
 
         self.group_container = group_container
 
         self.group_bar = QWidget(group_container)
         self.group_bar.setFixedHeight(toolbar_height)
-        self.group_bar.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.group_bar.setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         self.group_bar_layout = QHBoxLayout(self.group_bar)
         self.group_bar_layout.setContentsMargins(0, 0, 0, 0)
         self.group_bar_layout.setSpacing(1)
@@ -3871,7 +3890,7 @@ class RollCallTimerWindow(QWidget):
 
         group_row.addWidget(group_container, 1, Qt.AlignmentFlag.AlignLeft)
         group_row.addStretch(1)
-        toolbar_layout.addLayout(group_row)
+        toolbar_layout.addWidget(group_row_widget)
         layout.addLayout(toolbar_layout)
 
         self.stack = QStackedWidget(); layout.addWidget(self.stack, 1)
@@ -3911,7 +3930,7 @@ class RollCallTimerWindow(QWidget):
         self.timer_set_button = QPushButton("设定"); self.timer_set_button.clicked.connect(self.set_countdown_time)
         for b in (self.timer_mode_button, self.timer_start_pause_button, self.timer_reset_button, self.timer_set_button):
             b.setFont(compact_font)
-        timer_height = recommended_control_height(compact_font, extra=14, minimum=36)
+        timer_height = max(toolbar_height, recommended_control_height(compact_font, extra=10, minimum=toolbar_height))
         for b in (self.timer_mode_button, self.timer_start_pause_button, self.timer_reset_button, self.timer_set_button):
             apply_button_style(b, ButtonStyles.TOOLBAR, height=timer_height)
             b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
@@ -5357,13 +5376,20 @@ class RollCallTimerWindow(QWidget):
         self.group_buttons = {}
         if not self.groups:
             return
-        button_font = QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium)
-        button_height = recommended_control_height(button_font, extra=14, minimum=36)
+        button_font = getattr(self, "_toolbar_font", QFont("Microsoft YaHei UI", 9, QFont.Weight.Medium))
+        button_height = getattr(
+            self,
+            "_toolbar_height",
+            recommended_control_height(button_font, extra=12, minimum=34),
+        )
         for group in self.groups:
             button = QPushButton(group)
             button.setCheckable(True)
             button.setFont(button_font)
             apply_button_style(button, ButtonStyles.TOOLBAR, height=button_height)
+            width = max(button.sizeHint().width(), button.minimumSizeHint().width())
+            button.setFixedWidth(width)
+            button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
             button.clicked.connect(lambda _checked=False, name=group: self.on_group_change(name))
             self.group_bar_layout.addWidget(button)
             self.group_button_group.addButton(button)


### PR DESCRIPTION
## Summary
- enlarge and stabilise the roll call toolbar metrics so both button rows render fully and keep their sizing while swapping the class and showcase actions
- harden group button construction to reuse the shared toolbar metrics and lock button widths for consistent presentation during window resizes
- retune the pen settings dialog spacing so the colour grid and OK action sit higher and remain completely visible with compact margins

## Testing
- python -m compileall ClassroomTools.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c10c8fb4832c915fa314dd9cf7e9