### PR TITLE
Ensure single class selector and prune stale roll states

### DIFF
--- a/ClassroomTools.py
+++ b/ClassroomTools.py
@@ -21,7 +21,7 @@ import time
 import traceback
 import hashlib
 import hmac
-from collections import deque
+from collections import OrderedDict, deque
 from queue import Empty, Queue
 from dataclasses import dataclass
 from typing import (
@@ -80,6 +80,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMenu,
+    QInputDialog,
     QMessageBox,
     QPushButton,
     QSpacerItem,
@@ -182,6 +183,8 @@ try:
 except ImportError:
     pd = None
     PANDAS_AVAILABLE = False
+
+PANDAS_READY = PANDAS_AVAILABLE and pd is not None
 
 try:
     import openpyxl  # noqa: F401
@@ -3560,6 +3563,92 @@ class ScoreboardDialog(QDialog):
             self.setWindowState(self.windowState() | Qt.WindowState.WindowMaximized)
 
 
+@dataclass
+class ClassRollState:
+    current_group: str
+    group_remaining: Dict[str, List[int]]
+    group_last: Dict[str, Optional[int]]
+    global_drawn: List[int]
+    current_student: Optional[int] = None
+    pending_student: Optional[int] = None
+
+    def to_json(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "current_group": self.current_group,
+            "group_remaining": {group: list(values) for group, values in self.group_remaining.items()},
+            "group_last": {group: value for group, value in self.group_last.items()},
+            "global_drawn": list(self.global_drawn),
+            "current_student": self.current_student,
+            "pending_student": self.pending_student,
+        }
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> Optional["ClassRollState"]:
+        if not isinstance(data, Mapping):
+            return None
+
+        current_group = str(data.get("current_group", "") or "")
+
+        remaining_raw = data.get("group_remaining", {})
+        remaining: Dict[str, List[int]] = {}
+        if isinstance(remaining_raw, Mapping):
+            for key, values in remaining_raw.items():
+                if not isinstance(key, str):
+                    continue
+                if isinstance(values, Iterable) and not isinstance(values, (str, bytes)):
+                    cleaned: List[int] = []
+                    for value in values:
+                        try:
+                            cleaned.append(int(value))
+                        except (TypeError, ValueError):
+                            continue
+                    remaining[key] = cleaned
+
+        last_raw = data.get("group_last", {})
+        last: Dict[str, Optional[int]] = {}
+        if isinstance(last_raw, Mapping):
+            for key, value in last_raw.items():
+                if not isinstance(key, str):
+                    continue
+                if value is None:
+                    last[key] = None
+                    continue
+                try:
+                    last[key] = int(value)
+                except (TypeError, ValueError):
+                    continue
+
+        global_raw = data.get("global_drawn", [])
+        global_drawn: List[int] = []
+        if isinstance(global_raw, Iterable) and not isinstance(global_raw, (str, bytes)):
+            for value in global_raw:
+                try:
+                    global_drawn.append(int(value))
+                except (TypeError, ValueError):
+                    continue
+
+        def _parse_optional_int(value: Any) -> Optional[int]:
+            if value is None:
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+
+        current_student = _parse_optional_int(data.get("current_student"))
+        pending_student = _parse_optional_int(data.get("pending_student"))
+
+        return cls(
+            current_group=current_group,
+            group_remaining=remaining,
+            group_last=last,
+            global_drawn=global_drawn,
+            current_student=current_student,
+            pending_student=pending_student,
+        )
+
+
 class RollCallTimerWindow(QWidget):
     """集成点名与计时的主功能窗口。"""
     window_closed = pyqtSignal()
@@ -3573,7 +3662,7 @@ class RollCallTimerWindow(QWidget):
     def __init__(
         self,
         settings_manager: SettingsManager,
-        student_data,
+        student_workbook: Optional[StudentWorkbook],
         parent: Optional[QWidget] = None,
         *,
         defer_password_prompt: bool = False,
@@ -3591,10 +3680,14 @@ class RollCallTimerWindow(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.settings_manager = settings_manager
         self._encrypted_file_path = self.ENCRYPTED_STUDENT_FILE
-        base_dataframe = student_data
-        if isinstance(base_dataframe, pd.DataFrame):
-            pass
-        elif base_dataframe is None and PANDAS_AVAILABLE and pd is not None:
+        self.student_workbook: Optional[StudentWorkbook] = student_workbook
+        base_dataframe: Optional[PandasDataFrame] = None
+        if PANDAS_READY and self.student_workbook is not None:
+            try:
+                base_dataframe = self.student_workbook.get_active_dataframe()
+            except Exception:
+                base_dataframe = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
+        if base_dataframe is None and PANDAS_READY:
             base_dataframe = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
         self.student_data = base_dataframe
         self._student_data_pending_load = False
@@ -3602,13 +3695,17 @@ class RollCallTimerWindow(QWidget):
         self._student_file_encrypted = bool(encrypted_state)
         self._student_password = encrypted_password
         if defer_password_prompt:
-            base_empty = not isinstance(self.student_data, pd.DataFrame) or getattr(self.student_data, "empty", True)
+            base_empty = True
+            if PANDAS_READY and isinstance(self.student_data, pd.DataFrame):
+                base_empty = getattr(self.student_data, "empty", True)
+            elif self.student_data is not None:
+                base_empty = False
             if base_empty:
                 has_plain = os.path.exists(self.STUDENT_FILE)
                 has_encrypted = os.path.exists(self._encrypted_file_path)
                 if has_plain or has_encrypted:
                     self._student_data_pending_load = True
-                    if not isinstance(self.student_data, pd.DataFrame) and PANDAS_AVAILABLE and pd is not None:
+                    if self.student_data is None and PANDAS_READY:
                         self.student_data = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
         try:
             self._rng = random.SystemRandom()
@@ -3642,6 +3739,7 @@ class RollCallTimerWindow(QWidget):
         self.show_name = str_to_bool(s.get("show_name", "True"), True)
         if not self.show_id and not self.show_name: self.show_id = True
 
+        self.current_class_name = str(s.get("current_class", "")).strip()
         self.current_group_name = s.get("current_group", "全部")
         self.groups = ["全部"]
 
@@ -3657,6 +3755,7 @@ class RollCallTimerWindow(QWidget):
         # 统一维护一个全局已点名集合，确保“全部”分组与子分组状态一致
         self._global_drawn_students: set[int] = set()
         self._student_groups: Dict[int, set[str]] = {}
+        self._class_roll_states: Dict[str, ClassRollState] = {}
         self.timer_seconds_left = max(0, _get_int("timer_seconds_left", self.timer_countdown_minutes * 60 + self.timer_countdown_seconds))
         self.timer_stopwatch_seconds = max(0, _get_int("timer_stopwatch_seconds", 0))
         self.timer_running = str_to_bool(s.get("timer_running", "False"), False)
@@ -3713,7 +3812,10 @@ class RollCallTimerWindow(QWidget):
         self._save_timer.timeout.connect(self.save_settings)
 
         self._build_ui()
-        self._set_student_dataframe(self.student_data, propagate=False)
+        if self.student_workbook is not None and not self._student_data_pending_load:
+            self._apply_student_workbook(self.student_workbook, propagate=False)
+        else:
+            self._set_student_dataframe(self.student_data, propagate=False)
         self._apply_saved_fonts()
         self._update_menu_state()
         self._restore_group_state(s)
@@ -3761,15 +3863,38 @@ class RollCallTimerWindow(QWidget):
             button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
             button.setFont(compact_font)
 
+        def _lock_button_width(button: QPushButton) -> None:
+            """将按钮的宽度锁定在推荐值，避免随布局波动。"""
+
+            hint = button.sizeHint()
+            width = max(hint.width(), button.minimumSizeHint().width())
+            button.setMinimumWidth(width)
+            button.setMaximumWidth(width)
+            button.setSizePolicy(QSizePolicy.Policy.Fixed, button.sizePolicy().verticalPolicy())
+
         control_bar = QWidget()
         control_bar.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         control_layout = QHBoxLayout(control_bar)
         control_layout.setContentsMargins(0, 0, 0, 0)
         control_layout.setSpacing(2)
 
-        self.list_button = QPushButton("名单"); _setup_secondary_button(self.list_button)
-        self.list_button.clicked.connect(self.show_student_selector)
-        control_layout.addWidget(self.list_button)
+        self.reset_button = QPushButton("重置"); _setup_secondary_button(self.reset_button)
+        self.reset_button.clicked.connect(self.reset_roll_call_pools)
+        _lock_button_width(self.reset_button)
+        control_layout.addWidget(self.reset_button)
+
+        if hasattr(self, "class_button") and isinstance(self.class_button, QPushButton):
+            try:
+                self.class_button.deleteLater()
+            except Exception:
+                pass
+        self.class_button = QPushButton("班级"); _setup_secondary_button(self.class_button)
+        self.class_button.clicked.connect(self.show_class_selector)
+        reset_index = control_layout.indexOf(self.reset_button)
+        if reset_index == -1:
+            control_layout.addWidget(self.class_button)
+        else:
+            control_layout.insertWidget(reset_index, self.class_button)
 
         self.showcase_button = QPushButton("展示"); _setup_secondary_button(self.showcase_button)
         self.showcase_button.clicked.connect(self.show_scoreboard)
@@ -3778,10 +3903,6 @@ class RollCallTimerWindow(QWidget):
         self.encrypt_button = QPushButton(""); _setup_secondary_button(self.encrypt_button)
         self.encrypt_button.clicked.connect(self._on_encrypt_button_clicked)
         control_layout.addWidget(self.encrypt_button)
-
-        self.reset_button = QPushButton("重置"); _setup_secondary_button(self.reset_button)
-        self.reset_button.clicked.connect(self.reset_roll_call_pools)
-        control_layout.addWidget(self.reset_button)
 
         top.addWidget(control_bar, 0, Qt.AlignmentFlag.AlignLeft)
         top.addStretch(1)
@@ -3810,7 +3931,7 @@ class RollCallTimerWindow(QWidget):
         group_container.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         group_container_layout = QHBoxLayout(group_container)
         group_container_layout.setContentsMargins(0, 0, 0, 0)
-        group_container_layout.setSpacing(0)
+        group_container_layout.setSpacing(4)
 
         self.group_container = group_container
 
@@ -3826,9 +3947,15 @@ class RollCallTimerWindow(QWidget):
         self._rebuild_group_buttons_ui()
         group_container_layout.addWidget(self.group_bar, 1, Qt.AlignmentFlag.AlignLeft)
 
+        self.list_button = QPushButton("名单"); _setup_secondary_button(self.list_button)
+        self.list_button.clicked.connect(self.show_student_selector)
+        _lock_button_width(self.list_button)
+        group_container_layout.addWidget(self.list_button, 0, Qt.AlignmentFlag.AlignLeft)
+
         self.add_score_button = QPushButton("加分"); _setup_secondary_button(self.add_score_button)
         self.add_score_button.setEnabled(False)
         self.add_score_button.clicked.connect(self.increment_current_score)
+        self.add_score_button.setMinimumWidth(self.add_score_button.sizeHint().width())
         group_container_layout.addWidget(self.add_score_button, 0, Qt.AlignmentFlag.AlignLeft)
 
         group_row.addWidget(group_container, 1, Qt.AlignmentFlag.AlignLeft)
@@ -3937,7 +4064,7 @@ class RollCallTimerWindow(QWidget):
         return None
 
     def _set_student_dataframe(self, df: Optional[PandasDataFrame], *, propagate: bool = True) -> None:
-        if not (PANDAS_AVAILABLE and pd is not None):
+        if not PANDAS_READY:
             self.student_data = df
             return
         if df is None:
@@ -3969,46 +4096,455 @@ class RollCallTimerWindow(QWidget):
         self._ensure_group_pool(self.current_group_name, force_reset=True)
         self.current_student_index = None
         self._pending_passive_student = None
+        self._restore_active_class_state()
+        self._store_active_class_state()
+        self._update_class_button_label()
         if propagate:
             self._propagate_student_dataframe()
+        self.display_current_student()
+
+    def _apply_student_workbook(self, workbook: StudentWorkbook, *, propagate: bool) -> None:
+        self.student_workbook = workbook
+        self._prune_orphan_class_states()
+        if not PANDAS_READY:
+            self.current_class_name = workbook.active_class
+            self.student_data = None
+            return
+        if self.current_class_name:
+            workbook.set_active_class(self.current_class_name)
+        self.current_class_name = workbook.active_class
+        df = workbook.get_active_dataframe()
+        self._set_student_dataframe(df, propagate=propagate)
+
+    def _snapshot_current_class(self) -> None:
+        if not PANDAS_READY:
+            return
+        if self.student_workbook is None:
+            return
+        if self.student_data is None or not isinstance(self.student_data, pd.DataFrame):
+            return
+        class_name = (self.current_class_name or self.student_workbook.active_class or "").strip()
+        if not class_name:
+            available = self.student_workbook.class_names()
+            class_name = available[0] if available else self.student_workbook.active_class
+        if class_name not in self.student_workbook.class_names():
+            class_name = self.student_workbook.active_class
+        try:
+            snapshot = self.student_data.copy()
+        except Exception:
+            snapshot = pd.DataFrame(self.student_data)
+        self.student_workbook.update_class(class_name, snapshot)
+        self.student_workbook.set_active_class(class_name)
+        self.current_class_name = class_name
+        self._store_active_class_state(class_name)
+
+    def _resolve_active_class_name(self) -> str:
+        base = self.current_class_name
+        if not base and self.student_workbook is not None:
+            base = self.student_workbook.active_class
+        return str(base or "").strip()
+
+    def _capture_roll_state(self) -> Optional[ClassRollState]:
+        if not PANDAS_READY:
+            return None
+        if not isinstance(self.student_data, pd.DataFrame):
+            return None
+
+        base_sets: Dict[str, Set[int]] = {}
+        for group, indices in self._group_all_indices.items():
+            base_list = self._collect_base_indices(indices)
+            base_sets[group] = set(base_list)
+
+        if "全部" not in base_sets:
+            try:
+                base_sets["全部"] = set(self._collect_base_indices(list(self.student_data.index)))
+            except Exception:
+                base_sets["全部"] = set()
+
+        all_set = base_sets.get("全部", set())
+
+        remaining_payload: Dict[str, List[int]] = {}
+        for group, indices in self._group_remaining_indices.items():
+            base_set = base_sets.get(group, all_set)
+            if base_set:
+                restored = self._normalize_indices(indices, allowed=base_set)
+            else:
+                restored = []
+            remaining_payload[group] = restored
+
+        last_payload: Dict[str, Optional[int]] = {}
+        for group, value in self._group_last_student.items():
+            base_set = base_sets.get(group, all_set)
+            if value is None:
+                last_payload[group] = None
+                continue
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                last_payload[group] = None
+                continue
+            if base_set and idx not in base_set:
+                last_payload[group] = None
+            else:
+                last_payload[group] = idx
+
+        global_drawn_payload: List[int] = []
+        for value in sorted(self._global_drawn_students):
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                continue
+            if not all_set or idx in all_set:
+                global_drawn_payload.append(idx)
+
+        if self.groups:
+            if self.current_group_name in self.groups:
+                target_group = self.current_group_name
+            elif "全部" in self.groups:
+                target_group = "全部"
+            else:
+                target_group = self.groups[0]
+        else:
+            target_group = ""
+
+        def _sanitize_index(value: Any) -> Optional[int]:
+            if value is None:
+                return None
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                return None
+            if all_set and idx not in all_set:
+                return None
+            return idx
+
+        current_student = _sanitize_index(self.current_student_index)
+        pending_student = _sanitize_index(self._pending_passive_student)
+
+        return ClassRollState(
+            current_group=target_group,
+            group_remaining=remaining_payload,
+            group_last=last_payload,
+            global_drawn=global_drawn_payload,
+            current_student=current_student,
+            pending_student=pending_student,
+        )
+
+    def _store_active_class_state(self, class_name: Optional[str] = None) -> None:
+        if not PANDAS_READY:
+            return
+        self._prune_orphan_class_states()
+        target = (class_name or self._resolve_active_class_name()).strip()
+        if not target:
+            return
+        snapshot = self._capture_roll_state()
+        if snapshot is None:
+            return
+        self._class_roll_states[target] = snapshot
+
+    def _prune_orphan_class_states(self) -> None:
+        if not self._class_roll_states:
+            return
+        workbook = self.student_workbook
+        if workbook is None:
+            return
+        try:
+            valid = {str(name).strip() for name in workbook.class_names() if str(name).strip()}
+        except Exception:
+            valid = set()
+        if not valid:
+            self._class_roll_states.clear()
+            return
+        for stored_name in list(self._class_roll_states.keys()):
+            trimmed = str(stored_name).strip()
+            if not trimmed or trimmed not in valid:
+                self._class_roll_states.pop(stored_name, None)
+
+    def _encode_class_states(self) -> str:
+        payload = {name: state.to_json() for name, state in self._class_roll_states.items()}
+        return json.dumps(payload, ensure_ascii=False)
+
+    def _parse_legacy_roll_state(self, section: Mapping[str, str]) -> Optional[ClassRollState]:
+        def _load_dict(key: str) -> Dict[str, Any]:
+            raw = section.get(key, "")
+            if not raw:
+                return {}
+            try:
+                data = json.loads(raw)
+            except Exception:
+                return {}
+            return data if isinstance(data, dict) else {}
+
+        remaining = _load_dict("group_remaining")
+        last = _load_dict("group_last")
+
+        global_drawn_raw = section.get("global_drawn", "")
+        global_payload: List[int] = []
+        if global_drawn_raw:
+            try:
+                payload = json.loads(global_drawn_raw)
+            except Exception:
+                payload = []
+            if isinstance(payload, list):
+                for value in payload:
+                    try:
+                        global_payload.append(int(value))
+                    except (TypeError, ValueError):
+                        continue
+
+        payload_map: Dict[str, Any] = {
+            "current_group": section.get("current_group", self.current_group_name),
+            "group_remaining": remaining,
+            "group_last": last,
+            "global_drawn": global_payload,
+        }
+        return ClassRollState.from_mapping(payload_map)
+
+    def _restore_active_class_state(self) -> None:
+        if not PANDAS_READY:
+            return
+        class_name = self._resolve_active_class_name()
+        if not class_name:
+            return
+        snapshot = self._class_roll_states.get(class_name)
+        if snapshot is None:
+            return
+        self._apply_roll_state(snapshot)
+
+    def _apply_roll_state(self, snapshot: ClassRollState) -> None:
+        if not PANDAS_READY:
+            return
+
+        remaining_data = snapshot.group_remaining or {}
+        last_data = snapshot.group_last or {}
+        restored_global: Set[int] = set()
+        for value in snapshot.global_drawn:
+            try:
+                restored_global.add(int(value))
+            except (TypeError, ValueError):
+                continue
+
+        existing_global = set(restored_global)
+        self._global_drawn_students = set()
+        self._group_drawn_history["全部"] = self._global_drawn_students
+
+        for group, indices in remaining_data.items():
+            if group not in self._group_all_indices:
+                continue
+            base_list = self._collect_base_indices(self._group_all_indices[group])
+            base_set = set(base_list)
+            if base_set:
+                restored_list = self._normalize_indices(indices, allowed=base_set)
+            else:
+                restored_list = []
+            self._group_remaining_indices[group] = restored_list
+
+        for group, value in last_data.items():
+            if group not in self._group_all_indices:
+                continue
+            if value is None:
+                self._group_last_student[group] = None
+                continue
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                continue
+            base_indices = self._collect_base_indices(self._group_all_indices[group])
+            base_set = set(base_indices)
+            if base_set and idx not in base_set:
+                continue
+            self._group_last_student[group] = idx
+
+        for group, base_indices in self._group_all_indices.items():
+            normalized_base = self._collect_base_indices(base_indices)
+            remaining_set = set(self._normalize_indices(self._group_remaining_indices.get(group, [])))
+            drawn = {idx for idx in normalized_base if idx not in remaining_set}
+            if group != "全部" and existing_global:
+                drawn.update(idx for idx in existing_global if idx in normalized_base)
+            seq = list(self._group_remaining_indices.get(group, []))
+            seq.extend(idx for idx in normalized_base if idx not in seq)
+            self._group_initial_sequences[group] = seq
+            if group == "全部":
+                self._global_drawn_students.update(drawn)
+            else:
+                self._group_drawn_history[group] = drawn
+                self._global_drawn_students.update(drawn)
+
+        if existing_global:
+            self._global_drawn_students.update(existing_global)
+
+        self._group_drawn_history["全部"] = self._global_drawn_students
+        self._refresh_all_group_pool()
+
+        target_group = snapshot.current_group.strip() if snapshot.current_group else ""
+        if target_group not in self.groups:
+            target_group = "全部" if "全部" in self.groups else (self.groups[0] if self.groups else "全部")
+        self.current_group_name = target_group
+        self._update_group_button_state(target_group)
+
+        base_all = self._collect_base_indices(self._group_all_indices.get("全部", []))
+        base_all_set = set(base_all)
+
+        def _valid_index(value: Optional[int]) -> Optional[int]:
+            if value is None:
+                return None
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                return None
+            if base_all_set and idx not in base_all_set:
+                return None
+            return idx
+
+        self.current_student_index = _valid_index(snapshot.current_student)
+        self._pending_passive_student = _valid_index(snapshot.pending_student)
+
+        self._store_active_class_state(self._resolve_active_class_name())
+
+    def _update_class_button_label(self) -> None:
+        if not hasattr(self, "class_button"):
+            return
+        name = ""
+        if self.student_workbook is not None:
+            base_name = self.current_class_name or self.student_workbook.active_class
+            name = base_name.strip()
+        text = name or "班级"
+        self.class_button.setText(text)
+        metrics = self.class_button.fontMetrics()
+        baseline = metrics.horizontalAdvance("班级")
+        active_width = metrics.horizontalAdvance(text)
+        minimum = max(baseline, active_width) + 24
+        if self.class_button.minimumWidth() != minimum:
+            self.class_button.setMinimumWidth(minimum)
+        has_data = self.student_workbook is not None and not self.student_workbook.is_empty()
+        can_select = self.mode == "roll_call" and (has_data or self._student_data_pending_load)
+        self.class_button.setEnabled(can_select)
+        if has_data:
+            self.class_button.setToolTip("选择或新建班级")
+        else:
+            self.class_button.setToolTip("暂无班级数据，点击以尝试加载或创建班级")
+
+    def show_class_selector(self) -> None:
+        if self.mode != "roll_call":
+            return
+        if self._student_data_pending_load:
+            if not self._load_student_data_if_needed():
+                return
+        if self.student_workbook is None:
+            show_quiet_information(self, "暂无学生数据，无法选择班级。")
+            return
+        menu = QMenu(self)
+        current = self.current_class_name or self.student_workbook.active_class
+        for name in self.student_workbook.class_names():
+            action = menu.addAction(name)
+            action.setCheckable(True)
+            action.setChecked(name == current)
+            action.triggered.connect(lambda _checked=False, n=name: self._switch_class(n))
+        menu.addSeparator()
+        create_action = menu.addAction("新建班级...")
+        create_action.triggered.connect(self._create_new_class)
+        pos = self.class_button.mapToGlobal(self.class_button.rect().bottomLeft())
+        menu.exec(pos)
+
+    def _switch_class(self, class_name: str) -> None:
+        if self.student_workbook is None:
+            return
+        if class_name not in self.student_workbook.class_names():
+            return
+        target = class_name.strip()
+        current = self.current_class_name or self.student_workbook.active_class
+        if target == current:
+            return
+        if self._student_data_pending_load:
+            if not self._load_student_data_if_needed():
+                return
+        self._snapshot_current_class()
+        self.student_workbook.set_active_class(target)
+        self.current_class_name = target
+        if PANDAS_READY:
+            df = self.student_workbook.get_active_dataframe()
+        else:
+            df = None
+        self._set_student_dataframe(df, propagate=True)
+        self._schedule_save()
+
+    def _create_new_class(self) -> None:
+        if self._student_data_pending_load:
+            if not self._load_student_data_if_needed():
+                return
+        if self.student_workbook is None:
+            self.student_workbook = StudentWorkbook(OrderedDict(), active_class="")
+        if not PANDAS_READY:
+            show_quiet_information(self, "当前环境缺少 pandas，无法创建班级。")
+            return
+        self._snapshot_current_class()
+        suggested = f"班级{len(self.student_workbook.class_names()) + 1}" if self.student_workbook.class_names() else "班级1"
+        name, ok = QInputDialog.getText(
+            self,
+            "新建班级",
+            "请输入班级名称：",
+            QLineEdit.EchoMode.Normal,
+            suggested,
+        )
+        if not ok:
+            return
+        new_name = self.student_workbook.add_class(name)
+        self.current_class_name = new_name
+        self._apply_student_workbook(self.student_workbook, propagate=True)
+        self._schedule_save()
+        self._update_class_button_label()
 
     def _load_student_data_if_needed(self) -> bool:
         if not self._student_data_pending_load:
             return True
         if not (PANDAS_AVAILABLE and OPENPYXL_AVAILABLE):
             return False
-        df = load_student_data(self)
-        if df is None:
+        workbook = load_student_data(self)
+        if workbook is None:
             return False
         self._student_data_pending_load = False
-        self._set_student_dataframe(df, propagate=True)
+        self._apply_student_workbook(workbook, propagate=True)
         encrypted_state, encrypted_password = _get_session_student_encryption()
         self._student_file_encrypted = bool(encrypted_state)
         self._student_password = encrypted_password
         saved = self.settings_manager.load_settings().get("RollCallTimer", {})
         self._restore_group_state(saved)
         self._update_encryption_button()
+        self._update_class_button_label()
         self.display_current_student()
         self._schedule_save()
         return True
 
     def _handle_encrypt_student_file(self) -> None:
-        if not (PANDAS_AVAILABLE and pd is not None):
-            show_quiet_information(self, "当前环境缺少 pandas/openpyxl，无法执行加密。")
+        if not PANDAS_READY:
+            show_quiet_information(self, "当前环境缺少 pandas，无法执行加密。")
             return
         password = self._prompt_new_encryption_password()
         if not password:
             return
-        if self.student_data is None:
-            show_quiet_information(self, "没有可加密的学生数据。")
-            return
+        if self._student_data_pending_load:
+            if not self._load_student_data_if_needed():
+                return
+        if self.student_workbook is None:
+            if self.student_data is None or not isinstance(self.student_data, pd.DataFrame):
+                show_quiet_information(self, "没有可加密的学生数据。")
+                return
+            try:
+                snapshot = self.student_data.copy()
+            except Exception:
+                snapshot = pd.DataFrame(self.student_data)
+            class_name = self.current_class_name or "班级1"
+            self.current_class_name = class_name
+            self.student_workbook = StudentWorkbook(
+                OrderedDict({class_name: snapshot}),
+                active_class=class_name,
+            )
+        else:
+            self._snapshot_current_class()
         try:
-            df = self.student_data.copy()
-        except Exception:
-            df = pd.DataFrame(self.student_data)
-        try:
+            data = self.student_workbook.as_dict()
             _save_student_workbook(
-                df,
+                data,
                 self.STUDENT_FILE,
                 self._encrypted_file_path,
                 encrypted=True,
@@ -4019,6 +4555,7 @@ class RollCallTimerWindow(QWidget):
             self._student_password = password
             self._update_encryption_button()
             self._propagate_student_dataframe()
+            self._update_class_button_label()
             show_quiet_information(self, "已生成加密文件 students.xlsx.enc，并移除明文数据。")
             self._schedule_save()
         except Exception as exc:
@@ -4043,14 +4580,14 @@ class RollCallTimerWindow(QWidget):
             return
         try:
             buffer = io.BytesIO(plain_bytes)
-            df = pd.read_excel(buffer)
-            df = _normalize_student_dataframe(df, drop_incomplete=False)
+            raw_data = pd.read_excel(buffer, sheet_name=None)
+            workbook = StudentWorkbook(OrderedDict(raw_data), active_class="")
         except Exception as exc:
             show_quiet_information(self, f"读取解密后的学生数据失败：{exc}")
             return
         try:
             _save_student_workbook(
-                df,
+                workbook.as_dict(),
                 self.STUDENT_FILE,
                 self._encrypted_file_path,
                 encrypted=False,
@@ -4062,22 +4599,29 @@ class RollCallTimerWindow(QWidget):
         self._student_file_encrypted = False
         self._student_password = None
         _set_session_student_encryption(False, None)
-        self._apply_decrypted_student_data(df)
+        self._apply_decrypted_student_data(workbook)
         self._update_encryption_button()
         show_quiet_information(self, "已成功解密学生数据并恢复 students.xlsx。")
         self._schedule_save()
 
-    def _apply_decrypted_student_data(self, df: PandasDataFrame) -> None:
-        if not (PANDAS_AVAILABLE and pd is not None):
+    def _apply_decrypted_student_data(self, workbook: StudentWorkbook) -> None:
+        if not PANDAS_READY:
             return
-        self._set_student_dataframe(df, propagate=True)
+        self._apply_student_workbook(workbook, propagate=True)
         self.display_current_student()
 
     def _propagate_student_dataframe(self) -> None:
         parent = self.parent()
-        if parent is not None and hasattr(parent, "student_data"):
+        if parent is None:
+            return
+        if hasattr(parent, "student_data"):
             try:
                 setattr(parent, "student_data", self.student_data)
+            except Exception:
+                pass
+        if hasattr(parent, "student_workbook"):
+            try:
+                setattr(parent, "student_workbook", self.student_workbook)
             except Exception:
                 pass
 
@@ -4425,20 +4969,38 @@ class RollCallTimerWindow(QWidget):
     def _persist_student_scores(self) -> None:
         if not (PANDAS_AVAILABLE and OPENPYXL_AVAILABLE):
             return
-        if self.student_data is None:
+        if self._student_data_pending_load:
+            if not self._load_student_data_if_needed():
+                return
+        if self.student_workbook is None:
+            if self.student_data is None or not isinstance(self.student_data, pd.DataFrame):
+                return
+            try:
+                snapshot = self.student_data.copy()
+            except Exception:
+                snapshot = pd.DataFrame(self.student_data)
+            class_name = self.current_class_name or "班级1"
+            self.current_class_name = class_name
+            self.student_workbook = StudentWorkbook(
+                OrderedDict({class_name: snapshot}),
+                active_class=class_name,
+            )
+        else:
+            self._snapshot_current_class()
+        if self.student_workbook is None:
             return
         try:
             with self._score_write_lock:
-                df = self.student_data.copy()
-                df = _normalize_student_dataframe(df, drop_incomplete=False)
+                data = self.student_workbook.as_dict()
                 _save_student_workbook(
-                    df,
+                    data,
                     self.STUDENT_FILE,
                     self._encrypted_file_path,
                     encrypted=self._student_file_encrypted,
                     password=self._student_password,
                 )
             self._score_persist_failed = False
+            self._update_class_button_label()
         except Exception as exc:
             if not self._score_persist_failed:
                 show_quiet_information(self, f"保存成绩失败：{exc}")
@@ -4469,6 +5031,7 @@ class RollCallTimerWindow(QWidget):
         if hasattr(self, "add_score_button"):
             self.add_score_button.setVisible(is_roll)
         self._update_roll_call_controls()
+        self._update_class_button_label()
         if is_roll:
             if self._placeholder_on_show:
                 self.current_student_index = None
@@ -4841,94 +5404,44 @@ class RollCallTimerWindow(QWidget):
     def _restore_group_state(self, section: Mapping[str, str]) -> None:
         """从配置中恢复各分组剩余学生池，保持未抽学生不重复。"""
 
-        def _load_dict(key: str) -> Dict[str, object]:
-            raw = section.get(key, "")
-            if not raw:
-                return {}
-            try:
-                data = json.loads(raw)
-            except Exception:
-                return {}
-            return data if isinstance(data, dict) else {}
+        if not PANDAS_READY:
+            return
 
-        remaining_data = _load_dict("group_remaining")
-        last_data = _load_dict("group_last")
-
-        # 读取保存的全局已点名名单，保证窗口被关闭后重新打开时仍能继承上一轮的状态
-        global_drawn_raw = section.get("global_drawn", "")
-        restored_global: set[int] = set()
-        if global_drawn_raw:
+        raw_states = section.get("class_states", "")
+        restored_states: Dict[str, ClassRollState] = {}
+        if raw_states:
             try:
-                payload = json.loads(global_drawn_raw)
+                payload = json.loads(raw_states)
             except Exception:
-                payload = []
-            if isinstance(payload, list):
-                for value in payload:
-                    try:
-                        restored_global.add(int(value))
-                    except (TypeError, ValueError):
+                payload = {}
+            if isinstance(payload, dict):
+                for name, state_data in payload.items():
+                    key = str(name).strip()
+                    if not key:
                         continue
+                    state = ClassRollState.from_mapping(state_data)
+                    if state is not None:
+                        restored_states[key] = state
 
-        self._global_drawn_students.clear()
-        self._global_drawn_students.update(restored_global)
-        self._group_drawn_history["全部"] = self._global_drawn_students
+        self._class_roll_states = restored_states
+        self._prune_orphan_class_states()
 
-        # 先记录一份备份，稍后重新计算所有集合时需要与持久化信息交叉验证
-        existing_global = set(self._global_drawn_students)
+        active_class = self._resolve_active_class_name()
+        snapshot = self._class_roll_states.get(active_class)
+        if snapshot is None:
+            legacy = self._parse_legacy_roll_state(section)
+            if legacy is not None and active_class:
+                self._class_roll_states[active_class] = legacy
+                snapshot = legacy
 
-        # 从头构建全局集合，避免旧对象上的引用导致状态被意外清空
-        self._global_drawn_students = set()
-        self._group_drawn_history["全部"] = self._global_drawn_students
+        if snapshot is None:
+            self._ensure_group_pool(self.current_group_name)
+            return
 
-        for group, indices in remaining_data.items():
-            if group not in self._group_all_indices:
-                continue
-            base_list = self._collect_base_indices(self._group_all_indices[group])
-            base_set = set(base_list)
-            restored: List[int] = []
-            if isinstance(indices, list):
-                restored = self._normalize_indices(indices, allowed=base_set)
-            self._group_remaining_indices[group] = restored
-
-        for group, value in last_data.items():
-            if group not in self._group_all_indices:
-                continue
-            if value is None:
-                self._group_last_student[group] = None
-                continue
-            try:
-                idx = int(value)
-            except (TypeError, ValueError):
-                continue
-            if idx in self._group_all_indices[group]:
-                self._group_last_student[group] = idx
-
-        # 根据恢复后的剩余名单推导出每个分组已点名的学生集合
-        # 重新整理所有分组的已点名学生，并同步更新全局集合
-        for group, base_indices in self._group_all_indices.items():
-            normalized_base = self._collect_base_indices(base_indices)
-            remaining_set = set(self._normalize_indices(self._group_remaining_indices.get(group, [])))
-            drawn = {idx for idx in normalized_base if idx not in remaining_set}
-            if group != "全部" and existing_global:
-                # 在恢复时合并先前记录的全局名单，防止由于意外写入丢失导致遗漏
-                drawn.update(idx for idx in existing_global if idx in normalized_base)
-            seq = list(self._group_remaining_indices.get(group, []))
-            seq.extend(idx for idx in normalized_base if idx not in seq)
-            self._group_initial_sequences[group] = seq
-            if group == "全部":
-                # “全部”分组的已点名集合以全局集合为准
-                self._global_drawn_students.update(drawn)
-            else:
-                self._group_drawn_history[group] = drawn
-                self._global_drawn_students.update(drawn)
-
-        # 合并持久化阶段记录的全局集合，防止遗漏尚未恢复的记录
-        if existing_global:
-            self._global_drawn_students.update(existing_global)
-
-        # 最后重新指定“全部”分组引用当前全局集合，保持一致性
-        self._group_drawn_history["全部"] = self._global_drawn_students
-        self._refresh_all_group_pool()
+        self._apply_roll_state(snapshot)
+        sanitized = self._capture_roll_state()
+        if sanitized is not None and active_class:
+            self._class_roll_states[active_class] = sanitized
 
     def _ensure_group_pool(self, group_name: str, force_reset: bool = False) -> None:
         """确保指定分组仍有待抽取的学生，必要时重新洗牌。"""
@@ -5185,6 +5698,8 @@ class RollCallTimerWindow(QWidget):
             button.setCheckable(True)
             button.setFont(button_font)
             apply_button_style(button, ButtonStyles.TOOLBAR, height=button_height)
+            button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+            button.setMinimumWidth(button.sizeHint().width())
             button.clicked.connect(lambda _checked=False, name=group: self.on_group_change(name))
             self.group_bar_layout.addWidget(button)
             self.group_button_group.addButton(button)
@@ -5231,6 +5746,11 @@ class RollCallTimerWindow(QWidget):
         self.add_score_button.setEnabled(is_roll and has_student)
         self.list_button.setEnabled(is_roll and has_data)
         self.showcase_button.setEnabled(is_roll and has_data)
+        if hasattr(self, "class_button"):
+            has_workbook = self.student_workbook is not None and not self.student_workbook.is_empty()
+            can_select = is_roll and (has_workbook or self._student_data_pending_load)
+            self.class_button.setVisible(is_roll)
+            self.class_button.setEnabled(can_select)
         if hasattr(self, "encrypt_button"):
             self.encrypt_button.setVisible(is_roll)
             self.encrypt_button.setEnabled(is_roll and has_data)
@@ -5334,6 +5854,7 @@ class RollCallTimerWindow(QWidget):
         sec["show_name"] = bool_to_str(self.show_name)
         sec["speech_enabled"] = bool_to_str(self.speech_enabled)
         sec["speech_voice_id"] = self.selected_voice_id
+        sec["current_class"] = self.current_class_name
         sec["current_group"] = self.current_group_name
         sec["timer_countdown_minutes"] = str(self.timer_countdown_minutes)
         sec["timer_countdown_seconds"] = str(self.timer_countdown_seconds)
@@ -5348,6 +5869,10 @@ class RollCallTimerWindow(QWidget):
         sec["timer_font_size"] = str(self.last_timer_font_size)
         sec["scoreboard_order"] = self.scoreboard_order
         sec["students_encrypted"] = bool_to_str(self._student_file_encrypted)
+        self._prune_orphan_class_states()
+        if not self._student_data_pending_load:
+            self._store_active_class_state()
+        sec["class_states"] = self._encode_class_states()
         if self._student_data_pending_load:
             # 在尚未加载真实名单数据时，保留磁盘上已有的未点名状态，避免误把占位空列表写回
             # 此时直接返回，保持上一轮保存的名单信息不被覆盖。
@@ -5468,7 +5993,7 @@ def _decrypt_student_bytes(password: str, blob: bytes) -> bytes:
 
 
 def _normalize_text(value: object) -> str:
-    if PANDAS_AVAILABLE and pd is not None:
+    if PANDAS_READY:
         if pd.isna(value):
             return ""
     else:
@@ -5487,9 +6012,10 @@ def _normalize_text(value: object) -> str:
 
 def _normalize_student_dataframe(
     df: PandasDataFrame,
+    *,
     drop_incomplete: bool = True,
 ) -> PandasDataFrame:
-    if not (PANDAS_AVAILABLE and pd is not None):
+    if not PANDAS_READY:
         return df.copy()
 
     normalized = df.copy()
@@ -5528,24 +6054,115 @@ def _normalize_student_dataframe(
     return normalized
 
 
-def _write_student_workbook(file_path: str, df: PandasDataFrame) -> None:
-    data = _export_student_workbook_bytes(df)
+def _empty_student_dataframe() -> PandasDataFrame:
+    if not PANDAS_READY:
+        raise RuntimeError("Pandas support is required to create student data tables.")
+    template = pd.DataFrame({"学号": [], "姓名": [], "分组": [], "成绩": []})
+    return _normalize_student_dataframe(template, drop_incomplete=False)
+
+
+def _sanitize_sheet_name(name: str, fallback: str) -> str:
+    invalid = set("\\/:?*[]")
+    cleaned = "".join(ch for ch in str(name) if ch not in invalid).strip()
+    if not cleaned:
+        cleaned = fallback
+    if len(cleaned) > 31:
+        cleaned = cleaned[:31]
+    return cleaned
+
+
+@dataclass
+class StudentWorkbook:
+    """封装多班级学生名单，允许按工作表划分班级。"""
+
+    sheets: "OrderedDict[str, PandasDataFrame]"
+    active_class: str = ""
+
+    def __post_init__(self) -> None:
+        ordered: "OrderedDict[str, PandasDataFrame]" = OrderedDict()
+        if self.sheets:
+            for idx, (name, df) in enumerate(self.sheets.items(), start=1):
+                fallback = f"班级{idx}" if idx > 1 else "班级1"
+                safe_name = _sanitize_sheet_name(name, fallback)
+                try:
+                    normalized = _normalize_student_dataframe(df, drop_incomplete=False)
+                except Exception:
+                    normalized = pd.DataFrame(df)
+                ordered[safe_name] = normalized
+        if not ordered:
+            ordered["班级1"] = _empty_student_dataframe().copy()
+        self.sheets = ordered
+        if not self.active_class or self.active_class not in self.sheets:
+            self.active_class = next(iter(self.sheets))
+
+    def class_names(self) -> List[str]:
+        return list(self.sheets.keys())
+
+    def is_empty(self) -> bool:
+        if not self.sheets:
+            return True
+        for df in self.sheets.values():
+            try:
+                if not df.empty:
+                    return False
+            except AttributeError:
+                return False
+        return True
+
+    def get_active_dataframe(self) -> PandasDataFrame:
+        if not self.sheets:
+            return _empty_student_dataframe().copy()
+        if self.active_class not in self.sheets:
+            self.active_class = next(iter(self.sheets))
+        df = self.sheets.get(self.active_class)
+        if df is None:
+            return _empty_student_dataframe().copy()
+        try:
+            return df.copy()
+        except Exception:
+            return pd.DataFrame(df)
+
+    def set_active_class(self, class_name: str) -> None:
+        name = str(class_name).strip()
+        if name in self.sheets:
+            self.active_class = name
+
+    def update_class(self, class_name: str, df: PandasDataFrame) -> None:
+        try:
+            normalized = _normalize_student_dataframe(df, drop_incomplete=False)
+        except Exception:
+            normalized = pd.DataFrame(df)
+        self.sheets[class_name] = normalized
+        self.active_class = class_name
+
+    def add_class(self, class_name: str) -> str:
+        base_name = str(class_name).strip()
+        if not base_name:
+            base_name = f"班级{len(self.sheets) + 1}"
+        safe_name = _sanitize_sheet_name(base_name, base_name)
+        if safe_name in self.sheets:
+            suffix = 2
+            while f"{safe_name}_{suffix}" in self.sheets:
+                suffix += 1
+            safe_name = f"{safe_name}_{suffix}"
+        self.sheets[safe_name] = _empty_student_dataframe().copy()
+        self.active_class = safe_name
+        return safe_name
+
+    def as_dict(self) -> "OrderedDict[str, PandasDataFrame]":
+        ordered: "OrderedDict[str, PandasDataFrame]" = OrderedDict()
+        for name, df in self.sheets.items():
+            try:
+                ordered[name] = df.copy()
+            except Exception:
+                ordered[name] = pd.DataFrame(df)
+        return ordered
+
+
+def _write_student_workbook(file_path: str, data: Mapping[str, PandasDataFrame]) -> None:
+    payload = _export_student_workbook_bytes(data)
     tmp_dir = os.path.dirname(os.path.abspath(file_path)) or "."
     fd, tmp_path = tempfile.mkstemp(suffix=".xlsx", dir=tmp_dir)
-    try:
-        with os.fdopen(fd, "wb") as tmp_file:
-            tmp_file.write(data)
-        os.replace(tmp_path, file_path)
-    finally:
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(tmp_path)
-
-
-def _write_encrypted_student_workbook(file_path: str, df: PandasDataFrame, password: str) -> None:
-    data = _export_student_workbook_bytes(df)
-    payload = _encrypt_student_bytes(password, data)
-    tmp_dir = os.path.dirname(os.path.abspath(file_path)) or "."
-    fd, tmp_path = tempfile.mkstemp(suffix=".enc", dir=tmp_dir)
     try:
         with os.fdopen(fd, "wb") as tmp_file:
             tmp_file.write(payload)
@@ -5555,64 +6172,50 @@ def _write_encrypted_student_workbook(file_path: str, df: PandasDataFrame, passw
             os.remove(tmp_path)
 
 
-def _export_student_workbook_bytes(df: PandasDataFrame) -> bytes:
+def _write_encrypted_student_workbook(file_path: str, data: Mapping[str, PandasDataFrame], password: str) -> None:
+    payload = _export_student_workbook_bytes(data)
+    encrypted = _encrypt_student_bytes(password, payload)
+    tmp_dir = os.path.dirname(os.path.abspath(file_path)) or "."
+    fd, tmp_path = tempfile.mkstemp(suffix=".enc", dir=tmp_dir)
     try:
-        export_df = _normalize_student_dataframe(df, drop_incomplete=False)
-    except Exception:
-        export_df = df.copy()
+        with os.fdopen(fd, "wb") as tmp_file:
+            tmp_file.write(encrypted)
+        os.replace(tmp_path, file_path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(tmp_path)
 
-    if not OPENPYXL_AVAILABLE:
-        buffer = io.BytesIO()
-        export_df.to_excel(buffer, index=False)
-        return buffer.getvalue()
 
+def _export_student_workbook_bytes(data: Mapping[str, PandasDataFrame]) -> bytes:
+    normalized: "OrderedDict[str, PandasDataFrame]" = OrderedDict()
+    for idx, (name, df) in enumerate(data.items(), start=1):
+        fallback = f"班级{idx}" if idx > 1 else "班级1"
+        sheet_name = _sanitize_sheet_name(name, fallback)
+        try:
+            normalized_df = _normalize_student_dataframe(df, drop_incomplete=False)
+        except Exception:
+            normalized_df = pd.DataFrame(df)
+        normalized[sheet_name] = normalized_df
+    if not normalized:
+        normalized["班级1"] = _empty_student_dataframe().copy()
+
+    buffer = io.BytesIO()
     try:
-        from openpyxl import Workbook
-        from openpyxl.styles import Font
-    except Exception:
-        buffer = io.BytesIO()
-        export_df.to_excel(buffer, index=False)
-        return buffer.getvalue()
-
-    try:
-        workbook = Workbook()
-        worksheet = workbook.active
-        worksheet.title = "students"
-
-        headers = list(export_df.columns)
-        worksheet.append(headers)
-        header_font = Font(name="等线", size=12, bold=True)
-        body_font = Font(name="等线", size=12)
-        for cell in worksheet[1]:
-            cell.font = header_font
-
-        for row_values in export_df.itertuples(index=False, name=None):
-            normalized_row = []
-            for value in row_values:
-                if pd.isna(value):
-                    normalized_row.append(None)
-                else:
-                    normalized_row.append(value)
-            worksheet.append(tuple(normalized_row))
-
-        for row in worksheet.iter_rows(min_row=2):
-            for cell in row:
-                cell.font = body_font
-                if isinstance(cell.value, str):
-                    cell.value = cell.value.strip()
-
-        buffer = io.BytesIO()
-        workbook.save(buffer)
+        engine = "openpyxl" if OPENPYXL_AVAILABLE else None
+        with pd.ExcelWriter(buffer, engine=engine) as writer:  # type: ignore[call-arg]
+            for sheet_name, df in normalized.items():
+                df.to_excel(writer, sheet_name=sheet_name, index=False)
         buffer.seek(0)
         return buffer.getvalue()
     except Exception:
-        buffer = io.BytesIO()
-        export_df.to_excel(buffer, index=False)
+        buffer.seek(0)
+        first = next(iter(normalized.values()))
+        first.to_excel(buffer, index=False)
         return buffer.getvalue()
 
 
 def _save_student_workbook(
-    df: PandasDataFrame,
+    data: Mapping[str, PandasDataFrame],
     file_path: str,
     encrypted_file_path: str,
     *,
@@ -5622,22 +6225,25 @@ def _save_student_workbook(
     if encrypted:
         if not password:
             raise ValueError("缺少加密密码")
-        _write_encrypted_student_workbook(encrypted_file_path, df, password)
+        _write_encrypted_student_workbook(encrypted_file_path, data, password)
         with contextlib.suppress(FileNotFoundError):
             os.remove(file_path)
     else:
-        _write_student_workbook(file_path, df)
+        _write_student_workbook(file_path, data)
         with contextlib.suppress(FileNotFoundError):
             os.remove(encrypted_file_path)
 
 
-def load_student_data(parent: Optional[QWidget]) -> Optional[PandasDataFrame]:
+def load_student_data(parent: Optional[QWidget]) -> Optional[StudentWorkbook]:
     """从 students.xlsx 读取点名所需的数据，不存在时自动生成模板。"""
+
     if not (PANDAS_AVAILABLE and OPENPYXL_AVAILABLE):
         QMessageBox.warning(parent, "提示", "未安装 pandas/openpyxl，点名功能不可用。")
         return None
+
     file_path = RollCallTimerWindow.STUDENT_FILE
     encrypted_path = getattr(RollCallTimerWindow, "ENCRYPTED_STUDENT_FILE", file_path + ".enc")
+
     if not os.path.exists(file_path) and os.path.exists(encrypted_path):
         attempts = 0
         while attempts < 3:
@@ -5660,35 +6266,37 @@ def load_student_data(parent: Optional[QWidget]) -> Optional[PandasDataFrame]:
                     payload = fh.read()
                 plain_bytes = _decrypt_student_bytes(password, payload)
                 buffer = io.BytesIO(plain_bytes)
-                df = pd.read_excel(buffer)
-                df = _normalize_student_dataframe(df)
+                raw_data = pd.read_excel(buffer, sheet_name=None)
+                workbook = StudentWorkbook(OrderedDict(raw_data), active_class="")
                 _set_session_student_encryption(True, password)
-                return df
+                return workbook
             except Exception as exc:
                 attempts += 1
                 QMessageBox.warning(parent, "提示", f"解密失败：{exc}")
         QMessageBox.critical(parent, "错误", "多次输入密码失败，无法加载学生名单。")
         return None
+
     if not os.path.exists(file_path):
         try:
-            df = pd.DataFrame(
+            template = pd.DataFrame(
                 {"学号": [101, 102, 103], "姓名": ["张三", "李四", "王五"], "分组": ["A", "B", "A"], "成绩": [0, 0, 0]}
             )
-            df = _normalize_student_dataframe(df)
-            _write_student_workbook(file_path, df)
+            workbook = StudentWorkbook(OrderedDict({"班级1": template}), active_class="班级1")
+            _write_student_workbook(file_path, workbook.as_dict())
             show_quiet_information(parent, f"未找到学生名单，已为您创建模板文件：{file_path}")
             _set_session_student_encryption(False, None)
         except Exception as exc:
             QMessageBox.critical(parent, "错误", f"创建模板文件失败：{exc}")
             return None
+
     try:
-        df = pd.read_excel(file_path)
-        df = _normalize_student_dataframe(df)
-        _write_student_workbook(file_path, df)
+        raw_data = pd.read_excel(file_path, sheet_name=None)
+        workbook = StudentWorkbook(OrderedDict(raw_data), active_class="")
+        _write_student_workbook(file_path, workbook.as_dict())
         _set_session_student_encryption(False, None)
         if os.path.exists(encrypted_path):
             show_quiet_information(parent, "检测到同时存在加密文件，将优先使用明文 students.xlsx。")
-        return df
+        return workbook
     except Exception as exc:
         QMessageBox.critical(parent, "错误", f"无法加载学生名单，请检查文件格式。\n错误：{exc}")
         return None
@@ -5809,10 +6417,16 @@ class LauncherBubble(QWidget):
 
 
 class LauncherWindow(QWidget):
-    def __init__(self, settings_manager: SettingsManager, student_data: Optional[PandasDataFrame]) -> None:
+    def __init__(self, settings_manager: SettingsManager, student_workbook: Optional[StudentWorkbook]) -> None:
         super().__init__(None, Qt.WindowType.Tool | Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint)
         self.settings_manager = settings_manager
-        self.student_data = student_data
+        self.student_workbook: Optional[StudentWorkbook] = student_workbook
+        self.student_data: Optional[PandasDataFrame] = None
+        if PANDAS_READY and student_workbook is not None:
+            try:
+                self.student_data = student_workbook.get_active_dataframe()
+            except Exception:
+                self.student_data = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
         self.overlay: Optional[OverlayWindow] = None
         self.roll_call_window: Optional[RollCallTimerWindow] = None
         self._dragging = False; self._drag_offset = QPoint()
@@ -6005,16 +6619,20 @@ class LauncherWindow(QWidget):
             settings = self.settings_manager.load_settings().get("RollCallTimer", {})
             initial_mode = settings.get("mode", "roll_call")
             defer_prompt = initial_mode == "timer"
-            data = self.student_data
-            if data is None and not defer_prompt:
-                data = load_student_data(self)
-                if data is None:
+            if self.student_workbook is None and not defer_prompt:
+                workbook = load_student_data(self)
+                if workbook is None:
                     QMessageBox.warning(self, "提示", "学生数据加载失败，无法打开点名器。")
                     return
-                self.student_data = data
+                self.student_workbook = workbook
+                if PANDAS_READY:
+                    try:
+                        self.student_data = workbook.get_active_dataframe()
+                    except Exception:
+                        self.student_data = pd.DataFrame(columns=["学号", "姓名", "分组", "成绩"])
             self.roll_call_window = RollCallTimerWindow(
                 self.settings_manager,
-                self.student_data,
+                self.student_workbook,
                 parent=self,
                 defer_password_prompt=defer_prompt,
             )
@@ -6035,6 +6653,7 @@ class LauncherWindow(QWidget):
         window = self.roll_call_window
         if window is not None:
             try:
+                self.student_workbook = window.student_workbook
                 self.student_data = window.student_data
             except Exception:
                 pass
@@ -6201,11 +6820,11 @@ def main() -> None:
     QToolTip.setFont(QFont("Microsoft YaHei UI", 9))
 
     settings_manager = SettingsManager()
-    student_data = load_student_data(None) if PANDAS_AVAILABLE and not os.path.exists(
+    student_workbook = load_student_data(None) if PANDAS_AVAILABLE and not os.path.exists(
         RollCallTimerWindow.ENCRYPTED_STUDENT_FILE
     ) else None
 
-    window = LauncherWindow(settings_manager, student_data)
+    window = LauncherWindow(settings_manager, student_workbook)
     app.aboutToQuit.connect(window.handle_about_to_quit)
     window.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- rebuild the roll call toolbar so only one class selector remains and sits to the left of the fixed reset button
- prune stored roll-call snapshots to match the classes available in the current workbook and persist the active class state immediately after data loads
- refresh class-state persistence on load/save to keep per-class attendance history intact even when sheets are removed or encrypted

## Testing
- python -m compileall ClassroomTools.py

------
https://chatgpt.com/codex/tasks/task_e_68e5cf2dae7c832cabaf827082b9b92c